### PR TITLE
ci: add Claude Code review workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,43 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request for the papr RSS reader (Tauri 2 + React 19 + TypeScript + Rust).
+
+            Focus on:
+            - Correctness bugs and obvious logic errors
+            - Tauri command/IPC boundary: types match between TS (`src/`) and Rust (`src-tauri/`), error handling, panics on the Rust side
+            - React: hook rules, stale closures, unnecessary re-renders, effect cleanup, Zustand store mutations
+            - Rust: unwrap/expect in non-test code, `?` propagation, async cancellation, blocking calls in async context
+            - Security: command injection, path traversal, unsafe HTML rendering (the project parses RSS + markdown), unsanitized URLs
+            - Performance: virtualization (`@tanstack/react-virtual`), large list rendering, image loading
+            - Tests: are new code paths covered by vitest / cargo test?
+
+            Skip nitpicks about style or formatting. Use inline comments for concrete issues; reserve the summary comment for high-level findings.
+
+            Leave inline comments via the `mcp__github_inline_comment__create_inline_pr_comment` tool.
+          claude_args: '--allowed-tools "mcp__github_inline_comment__create_inline_pr_comment"'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,36 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## Summary
- Add `.github/workflows/claude-code-review.yml` — runs Claude on every PR `opened`/`synchronize`, leaves inline comments via the GitHub MCP tool. Prompt is tailored to the Tauri 2 + React 19 + Rust stack.
- Add `.github/workflows/claude.yml` — `@claude`-triggered conversation on issues, PR comments, PR review comments, and PR reviews.
- Both authenticated via the `CLAUDE_CODE_OAUTH_TOKEN` repo secret (already configured).

## Test plan
- [ ] This PR itself triggers `Claude Code Review` and Claude posts a review summary
- [ ] Commenting `@claude what does this workflow do?` on this PR triggers the `Claude Code` workflow and Claude replies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI workflows that run AI-based reviews on pull requests and when the AI is mentioned in issue or review comments
  * Enabled automated inline AI feedback on pull requests
  * Configured workflows to trigger on PR events and relevant comment/issue events to surface review suggestions in-line

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/l0ng-ai/papr/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->