### PR TITLE
fix(sync): map FreshRSS/GReader folders to local folders (#5)

### DIFF
--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -617,6 +617,19 @@ pub fn move_feed(conn: &Connection, id: i64, folder_id: Option<i64>) -> AppResul
     Ok(())
 }
 
+/// The folder a feed currently sits in, if any. Used by sync to tell an
+/// already-filed feed (leave it) from an unfiled one (adopt the server folder).
+pub fn feed_folder_id(conn: &Connection, id: i64) -> AppResult<Option<i64>> {
+    Ok(conn
+        .query_row(
+            "SELECT folder_id FROM feeds WHERE id = ?1",
+            params![id],
+            |r| r.get::<_, Option<i64>>(0),
+        )
+        .optional()?
+        .flatten())
+}
+
 /// Set a feed's display title to a user-chosen value. `custom_title` is also
 /// raised so a later refresh's `update_feed_meta` does not revert the rename
 /// back to the feed document's own `<title>`.

--- a/src-tauri/src/sync.rs
+++ b/src-tauri/src/sync.rs
@@ -146,6 +146,35 @@ struct SubList {
 struct Sub {
     url: Option<String>,
     title: Option<String>,
+    #[serde(default)]
+    categories: Vec<SubCat>,
+}
+/// A GReader category ("label") a subscription belongs to. FreshRSS/Miniflux
+/// folders surface here; we map the first named one onto a local folder.
+#[derive(Deserialize)]
+struct SubCat {
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    label: Option<String>,
+}
+impl SubCat {
+    /// Human folder name for this category. Prefer the explicit `label`,
+    /// otherwise derive it from the `user/-/label/NAME` id. `None` for an
+    /// unnamed category, so it is skipped rather than creating a blank folder.
+    fn folder_name(&self) -> Option<String> {
+        self.label
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .or_else(|| {
+                self.id
+                    .rsplit_once("/label/")
+                    .map(|(_, n)| n.trim().to_string())
+                    .filter(|s| !s.is_empty())
+            })
+    }
 }
 
 #[derive(Deserialize)]
@@ -338,13 +367,33 @@ pub async fn sync_now(app: &AppHandle) -> AppResult<usize> {
         let state = app.state::<AppState>();
         let conn = state.db.lock().await;
         for sub in subs.subscriptions {
+            // Resolve the server-side folder (GReader "label") before moving
+            // `url` out of `sub`, mapping it onto a local folder by name.
+            let folder_id = sub
+                .categories
+                .iter()
+                .find_map(SubCat::folder_name)
+                .map(|name| db::folder_id_by_name(&conn, &name))
+                .transpose()?;
             let Some(feed_url) = sub.url.filter(|u| !u.is_empty()) else {
                 continue;
             };
-            if db::find_feed_by_url(&conn, &feed_url)?.is_none() {
-                let title = sub.title.unwrap_or_else(|| feed_url.clone());
-                let st = parse::detect_source_type(&feed_url);
-                let _ = db::insert_feed(&conn, &feed_url, None, &title, None, st, None);
+            match db::find_feed_by_url(&conn, &feed_url)? {
+                None => {
+                    let title = sub.title.unwrap_or_else(|| feed_url.clone());
+                    let st = parse::detect_source_type(&feed_url);
+                    let _ = db::insert_feed(&conn, &feed_url, None, &title, None, st, folder_id);
+                }
+                // Reconcile the folder for a feed we already track, but only
+                // when it isn't filed locally yet — don't yank a feed the user
+                // has organised by hand back into the server's folder.
+                Some(id) => {
+                    if let Some(folder_id) = folder_id {
+                        if db::feed_folder_id(&conn, id)?.is_none() {
+                            db::move_feed(&conn, id, Some(folder_id))?;
+                        }
+                    }
+                }
             }
         }
     }
@@ -388,4 +437,40 @@ pub async fn sync_now(app: &AppHandle) -> AppResult<usize> {
         }
     }
     Ok(reconciled)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cat(id: &str, label: Option<&str>) -> SubCat {
+        SubCat {
+            id: id.to_string(),
+            label: label.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn folder_name_prefers_label() {
+        assert_eq!(
+            cat("user/-/label/Tech", Some("Tech")).folder_name().as_deref(),
+            Some("Tech")
+        );
+    }
+
+    #[test]
+    fn folder_name_falls_back_to_label_id() {
+        // Some servers omit the human label; derive it from the id instead.
+        assert_eq!(
+            cat("user/-/label/科技", None).folder_name().as_deref(),
+            Some("科技")
+        );
+    }
+
+    #[test]
+    fn folder_name_skips_unnamed_categories() {
+        // A state tag (not a label) or a blank label is not a folder.
+        assert_eq!(cat("user/-/state/com.google/read", None).folder_name(), None);
+        assert_eq!(cat("", Some("   ")).folder_name(), None);
+    }
 }


### PR DESCRIPTION
Closes #5

## 问题
FreshRSS 同步进来的订阅源全是扁平的，看不到服务端的文件夹结构。

## 根因
`sync.rs` 拉取订阅列表时，`Sub` 结构只反序列化了 `url` / `title`，**丢弃了每个订阅的 `categories`**（GReader 的 "label"，即 FreshRSS/Miniflux 文件夹）。所以本地插入的 feed 永远没有 `folder_id`。

## 改动
- 解析 GReader `categories`，新增 `SubCat`，按 `label`（缺失时回退到 `user/-/label/NAME` 的 id）取出文件夹名。
- 通过 `folder_id_by_name` 解析/创建本地文件夹（与 OPML 导入同一路径，自动去重、大小写不敏感）。
- 新订阅的 feed 插入时直接归入对应文件夹。
- 对**已同步**的 feed：仅当它本地还没归类时才回填文件夹，避免把用户手动整理过的 feed 拽回服务端文件夹。

## 测试
- 新增 `SubCat::folder_name` 单测（label 优先 / id 回退 / 跳过未命名分类）。
- `cargo test --lib sync::` 通过，`cargo build` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subscriptions are now automatically organized into local folders based on your server-side categories and labels. During sync, newly discovered subscriptions are automatically placed into their corresponding local folders. Existing subscriptions are intelligently updated to match their current server-side folder organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->