### PR TITLE
fix(reader): load feed images without a Referer (#9)

### DIFF
--- a/src-tauri/src/sanitize.rs
+++ b/src-tauri/src/sanitize.rs
@@ -14,7 +14,16 @@ pub fn sanitize(html: &str, base: Option<&str>) -> String {
     let mut builder = Builder::default();
     builder
         .link_rel(Some("noopener noreferrer nofollow"))
-        .add_generic_attributes(["loading"]);
+        .add_generic_attributes(["loading"])
+        // Load every feed image without a `Referer`. Common image hosts —
+        // notably Sina's `*.sinaimg.cn` CDN, which backs 喷嚏图卦 and many
+        // Weibo-sourced feeds — hotlink-protect by Referer: a request carrying
+        // the reader's own origin is 403'd, while one with no Referer is
+        // served. Without this the image silently fails to load (and the
+        // reader then hides the broken `<img>`), so the article looks
+        // text-only. Forcing the attribute on every `<img>` also overrides any
+        // weaker policy the feed shipped.
+        .set_tag_attribute_value("img", "referrerpolicy", "no-referrer");
 
     let parsed_base = base.and_then(|b| Url::parse(b).ok());
     if let Some(b) = parsed_base {
@@ -212,6 +221,29 @@ mod tests {
     fn first_image_falls_through_relative_to_next_absolute() {
         let html = r#"<img src="/rel.png"><img src="https://ex.com/real.jpg">"#;
         assert_eq!(first_image(html).as_deref(), Some("https://ex.com/real.jpg"));
+    }
+
+    #[test]
+    fn sanitize_marks_images_no_referrer() {
+        // Hotlink-protected hosts (e.g. *.sinaimg.cn behind 喷嚏图卦) 403 a
+        // request that carries the reader's origin as Referer; `no-referrer`
+        // is what makes the image load.
+        let out = sanitize(r#"<img src="https://wx1.sinaimg.cn/large/a.jpg">"#, None);
+        assert!(
+            out.contains(r#"referrerpolicy="no-referrer""#),
+            "img missing no-referrer policy: {out}"
+        );
+    }
+
+    #[test]
+    fn sanitize_overrides_weaker_image_referrer_policy() {
+        // A feed shipping its own (Referer-leaking) policy must not win.
+        let out = sanitize(
+            r#"<img src="https://wx1.sinaimg.cn/large/a.jpg" referrerpolicy="origin">"#,
+            None,
+        );
+        assert!(out.contains(r#"referrerpolicy="no-referrer""#), "{out}");
+        assert!(!out.contains(r#"referrerpolicy="origin""#), "{out}");
     }
 
     #[test]

--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -614,6 +614,10 @@ export default function Reader({ onToast }: Props) {
               <img
                 src={a.imageUrl}
                 alt=""
+                // No Referer, for the same hotlink-protection reason feed-body
+                // images are sanitized this way (e.g. *.sinaimg.cn 403s a
+                // request carrying our origin). See `sanitize`.
+                referrerPolicy="no-referrer"
                 onError={() => setHeroBroken(true)}
               />
             )


### PR DESCRIPTION
Closes #9

## 现象
喷嚏图卦等订阅源,文字正常但图片加载不出来,而且**连加载失败的图标都没有**。

## 复现 / 根因(已确认)
1. 喷嚏图卦正文图片托管在新浪微博图床 `*.sinaimg.cn`,该 CDN 按 `Referer` 做防盗链。实测对 `sinaimg.cn` 的请求返回 **403**(Tengine)。
2. webview 渲染 `<img>` 时默认带上自身 origin 作为 `Referer`,不在新浪白名单 → 403。
3. `Reader.tsx` 已有一个 effect 会把加载失败的 `<img>` 设为 `display:none` —— 于是图片既不显示、也看不到破图标,文章看起来像纯文字。现象与 issue 描述完全吻合。

这是 Weibo 图床外链的公认问题:**请求不带 Referer 时图床会正常返回图片**,社区通行解法就是给 `<img>` 加 `referrerpolicy="no-referrer"`。

## 改动
- `sanitize`:对每个正文 `<img>` 强制 `referrerpolicy="no-referrer"`(覆盖 feed 自带的弱策略)。这是所有订阅 HTML 的统一入口。
- Reader 的 hero 大图(由前端渲染,不经 sanitize)同样加上 `referrerPolicy="no-referrer"`。
- YouTube iframe 原有的显式 referrer 策略不受影响(按元素覆盖)。

> 说明:`sanitize` 在入库时生效,因此对**新抓取/刷新**的文章立即生效;喷嚏图卦是每日新帖,更新后次日的图卦图片即可正常显示。

## 为什么不用后端图片代理
最初考虑过把图片绕经 Rust 加 Referer/UA 再回传,但新浪图床对"空 Referer"本就放行,`no-referrer` 即可对症解决,且不引入新协议、不把全部图片流量绕经后端(那反而可能被 Cloudflare 之类打断)。

## 测试
- 新增 `sanitize` 单测:图片带 `no-referrer`、覆盖 feed 自带的 `referrerpolicy`。
- `cargo test --lib` 全绿(192 passed),`tsc --noEmit` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image loading compatibility with hotlink-protected CDN providers for both feed images and hero images

* **Tests**
  * Added regression tests for image loading behavior validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->