### PR TITLE
feat(reader): native context menu for copy / save image (#7)

### DIFF
--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -549,6 +549,14 @@ export default function Reader({ onToast }: Props) {
         ref={scrollRef}
         onScroll={onScroll}
         onContextMenu={(e) => {
+          // Defer to the webview's native menu over an image or a text
+          // selection, so Copy / Save Image / Copy Image Address are available
+          // (see the global handler in main.tsx). Our menu serves everywhere
+          // else in the reader.
+          const target = e.target as HTMLElement;
+          const sel = window.getSelection();
+          const hasSelection = !!sel && !sel.isCollapsed && sel.toString().trim().length > 0;
+          if (target.closest("img") || hasSelection) return;
           e.preventDefault();
           setCtxMenu({ x: e.clientX, y: e.clientY });
         }}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -24,11 +24,24 @@ document.documentElement.dataset.platform = isMac ? "mac" : "other";
 // Suppress the webview's default context menu — its "Reload / Back / Inspect"
 // entries belong to a browser, not a finished app. Editable surfaces still get
 // the native menu so paste / select-all / spellcheck stay available.
+//
+// Two reader cases also keep the native menu, because there the webview offers
+// genuinely useful, content-only entries (no Reload/Back/Inspect): a right-click
+// on an article image (Save Image / Copy Image / Copy Image Address) and a
+// right-click over a text selection (Copy / Look Up / Translate). Everywhere
+// else the app's own context menu takes over.
 window.addEventListener("contextmenu", (e) => {
   const t = e.target as HTMLElement | null;
   if (t?.closest("input, textarea, [contenteditable=''], [contenteditable='true']")) return;
+  if (t?.closest(".reader-content") && (t.closest("img") || hasSelection())) return;
   e.preventDefault();
 });
+
+/** Whether the user currently has a non-collapsed text selection. */
+function hasSelection(): boolean {
+  const sel = window.getSelection();
+  return !!sel && !sel.isCollapsed && sel.toString().trim().length > 0;
+}
 
 const queryClient = new QueryClient({
   defaultOptions: {


### PR DESCRIPTION
Closes #7

## 现状(复现)
`main.tsx` 里有一个全局监听器,对**除输入框外**的所有右键都 `e.preventDefault()`,目的是隐藏 webview 自带的"重新载入/后退/检查"等浏览器式菜单项。代价是:在文章正文里右键文字或图片,**什么菜单都没有**——既不能复制,也不能保存图片。

## 改动
保持总体屏蔽,但对正文里两种"只会出现内容相关项、不会出现 Reload/Inspect"的情况放行 webview 原生菜单:
- 右键文章**图片** → 存储图像 / 拷贝图像 / 拷贝图像地址;
- 右键**选中的文字** → 拷贝 / 查询 / 翻译。

正文其它位置仍由 app 自有的右键菜单(AI 摘要、翻译、复制链接、专注模式)接管。实现上只放开了 `main.tsx` 的全局拦截和 `reader-scroll` 的 `onContextMenu`,对这两种情况不再 `preventDefault`。

> 说明:文字本来就可以选中并用 ⌘C/Ctrl+C 复制;本 PR 补的是**右键菜单**入口,以及图片的保存/复制。原生菜单由各平台 webview 提供(macOS WKWebView / Windows WebView2 / Linux WebKitGTK),无需额外后端或插件。

## 验证
- `tsc --noEmit` 通过;`vitest` 60 项全过。
- 行为建议在 app 内手动确认:正文右键图片应出现"存储图像"等项,选中文字右键应出现"拷贝"。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context menu behavior by intelligently handling image and text selection scenarios: the native browser context menu now displays when right-clicking on images or selected text, enabling standard copy/paste and image operations. Custom context menus remain available for other application interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->