### PR TITLE
feat(reader): app context menu for copy / save image (#7 follow-up)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -394,6 +394,47 @@ pub async fn extract_fulltext(state: State<'_, AppState>, article_id: i64) -> Ap
     Ok(extracted)
 }
 
+// ─────────────────────────── image download ───────────────────────────
+
+/// A mainstream browser User-Agent. Some image hosts gate on it in addition to
+/// the `Referer`; sending a browser UA (and no Referer) mirrors what the webview
+/// itself does when it renders the image, so a save succeeds wherever the inline
+/// render did.
+const IMAGE_UA: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) \
+    AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
+
+/// Upper bound on a saved image, so a hostile or mistyped URL can't balloon
+/// memory. Well above any real article image.
+const MAX_IMAGE_BYTES: u64 = 25 * 1024 * 1024;
+
+/// Fetch a feed image's bytes for the reader's "Save image" action.
+///
+/// Done in Rust rather than via the webview so the request can omit the
+/// `Referer` that hotlink-protected hosts (notably `*.sinaimg.cn` behind
+/// 喷嚏图卦) reject — the same workaround that lets these images render at all
+/// (see `sanitize`). The frontend wraps the returned bytes in a download.
+#[tauri::command]
+pub async fn fetch_image(state: State<'_, AppState>, url: String) -> AppResult<tauri::ipc::Response> {
+    if !(url.starts_with("http://") || url.starts_with("https://")) {
+        return Err(AppError::code("badImageUrl"));
+    }
+    let http = state.http();
+    let resp = http
+        .get(&url)
+        .header("User-Agent", IMAGE_UA)
+        .send()
+        .await?
+        .error_for_status()?;
+    if resp.content_length().is_some_and(|n| n > MAX_IMAGE_BYTES) {
+        return Err(AppError::code("imageTooLarge"));
+    }
+    let bytes = resp.bytes().await?;
+    if bytes.len() as u64 > MAX_IMAGE_BYTES {
+        return Err(AppError::code("imageTooLarge"));
+    }
+    Ok(tauri::ipc::Response::new(bytes.to_vec()))
+}
+
 // ─────────────────────────── OPML ───────────────────────────
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -204,6 +204,7 @@ pub fn run() {
             commands::mark_all_read,
             commands::smart_counts,
             commands::extract_fulltext,
+            commands::fetch_image,
             commands::import_opml,
             commands::export_opml,
             commands::get_setting,

--- a/src/api.ts
+++ b/src/api.ts
@@ -31,6 +31,12 @@ export const renameFolder = (id: number, name: string) =>
 export const deleteFolder = (id: number) =>
   invoke<void>("delete_folder", { id });
 
+// ── images ──
+/** Fetch an image's raw bytes via the backend (no Referer, to defeat hotlink
+ *  protection) for the reader's "Save image" action. Returns the bytes. */
+export const fetchImage = (url: string) =>
+  invoke<ArrayBuffer>("fetch_image", { url });
+
 // ── feeds ──
 export const listFeeds = () => invoke<Feed[]>("list_feeds");
 export const addFeed = (url: string, folderId: number | null) =>

--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -8,6 +8,7 @@ import { usePlayer } from "../player";
 import { useTranslationJobs } from "../translation";
 import { useArticleActions } from "../hooks/articleActions";
 import { renderMarkdown } from "../lib/markdown";
+import { downloadBlob, imageFilename } from "../lib/download";
 import { fullDate } from "../lib/feedMeta";
 import { isMac } from "../lib/platform";
 import { reportError, toast } from "../toast";
@@ -157,7 +158,14 @@ export default function Reader({ onToast }: Props) {
   const [showExtracted, setShowExtracted] = useState(autoExtract);
   const [showTranslation, setShowTranslation] = useState(false);
   const [tagPick, setTagPick] = useState<{ x: number; y: number } | null>(null);
-  const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number } | null>(null);
+  const [ctxMenu, setCtxMenu] = useState<{
+    x: number;
+    y: number;
+    // Set when the right-click landed on an article image / over a text
+    // selection, so the menu can offer image- and copy-specific actions.
+    imageUrl?: string;
+    selection?: string;
+  } | null>(null);
   const [heroBroken, setHeroBroken] = useState(false);
   const [progress, setProgress] = useState(0);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -331,6 +339,21 @@ export default function Reader({ onToast }: Props) {
   const copyLink = () => {
     if (!a?.url) return;
     navigator.clipboard.writeText(a.url).then(() => onToast(t("reader.linkCopied")), () => {});
+  };
+  const copyText = (text: string, toastKey: string) => {
+    navigator.clipboard.writeText(text).then(() => onToast(t(toastKey)), () => {});
+  };
+  // Save a feed image to disk. The bytes are fetched in Rust (not the webview)
+  // so the request carries no Referer — the same hotlink workaround that lets
+  // these images render at all (see sanitize.rs). The download itself reuses
+  // the app's blob-anchor mechanism.
+  const saveImage = async (url: string) => {
+    try {
+      const buf = await api.fetchImage(url);
+      downloadBlob(new Blob([buf]), imageFilename(url));
+    } catch {
+      toast.error(t("reader.imageSaveFailed"));
+    }
   };
   const share = () => {
     if (!a?.url) return;
@@ -549,16 +572,20 @@ export default function Reader({ onToast }: Props) {
         ref={scrollRef}
         onScroll={onScroll}
         onContextMenu={(e) => {
-          // Defer to the webview's native menu over an image or a text
-          // selection, so Copy / Save Image / Copy Image Address are available
-          // (see the global handler in main.tsx). Our menu serves everywhere
-          // else in the reader.
-          const target = e.target as HTMLElement;
-          const sel = window.getSelection();
-          const hasSelection = !!sel && !sel.isCollapsed && sel.toString().trim().length > 0;
-          if (target.closest("img") || hasSelection) return;
           e.preventDefault();
-          setCtxMenu({ x: e.clientX, y: e.clientY });
+          // Capture what the click landed on so the menu can add image- and
+          // selection-specific actions (the native menu is suppressed app-wide;
+          // see main.tsx).
+          const img = (e.target as HTMLElement).closest("img");
+          const sel = window.getSelection();
+          const selection =
+            sel && !sel.isCollapsed ? sel.toString().trim() : "";
+          setCtxMenu({
+            x: e.clientX,
+            y: e.clientY,
+            imageUrl: (img as HTMLImageElement | null)?.currentSrc || img?.getAttribute("src") || undefined,
+            selection: selection || undefined,
+          });
         }}
       >
         <article className="article reader-content" key={a.id}>
@@ -729,6 +756,33 @@ export default function Reader({ onToast }: Props) {
           x={ctxMenu.x}
           y={ctxMenu.y}
           items={[
+            ...(ctxMenu.selection
+              ? [
+                  {
+                    icon: "copy" as const,
+                    label: t("reader.ctxCopy"),
+                    onClick: () => copyText(ctxMenu.selection!, "reader.textCopied"),
+                  },
+                ]
+              : []),
+            ...(ctxMenu.imageUrl
+              ? [
+                  {
+                    icon: "arrow-down" as const,
+                    label: t("reader.ctxSaveImage"),
+                    onClick: () => saveImage(ctxMenu.imageUrl!),
+                  },
+                  {
+                    icon: "copy" as const,
+                    label: t("reader.ctxCopyImageAddress"),
+                    onClick: () =>
+                      copyText(ctxMenu.imageUrl!, "reader.imageAddressCopied"),
+                  },
+                ]
+              : []),
+            ...(ctxMenu.selection || ctxMenu.imageUrl
+              ? [{ separator: true as const }]
+              : []),
             {
               icon: aiOpen ? "sparkle-fill" : "sparkle",
               label: t("reader.tbAiSummary"),

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -18,7 +18,14 @@ export function downloadFile(
   filename: string,
   mimeType: string,
 ): void {
-  const blob = new Blob([content], { type: mimeType });
+  downloadBlob(new Blob([content], { type: mimeType }), filename);
+}
+
+/** Download an already-built Blob as `filename`. Used for binary saves (e.g. a
+ *  feed image fetched as bytes), where the content isn't a string. The object
+ *  URL is same-origin, so the `download` attribute is honoured even in
+ *  WKWebView. */
+export function downloadBlob(blob: Blob, filename: string): void {
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
@@ -31,4 +38,16 @@ export function downloadFile(
     a.remove();
     URL.revokeObjectURL(url);
   }, 0);
+}
+
+/** A sensible download filename for an image URL: its last path segment (query
+ *  and fragment stripped), falling back to "image" when the URL has none. */
+export function imageFilename(url: string): string {
+  try {
+    const name = new URL(url).pathname.split("/").filter(Boolean).pop();
+    if (name) return decodeURIComponent(name);
+  } catch {
+    /* not a parseable URL — fall through to the default */
+  }
+  return "image";
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -158,6 +158,12 @@
   "reader": {
     "fullTextExtracted": "Full text extracted",
     "linkCopied": "Link copied",
+    "ctxCopy": "Copy",
+    "ctxSaveImage": "Save image",
+    "ctxCopyImageAddress": "Copy image address",
+    "textCopied": "Copied",
+    "imageAddressCopied": "Image address copied",
+    "imageSaveFailed": "Couldn't save the image",
     "loadError": "Couldn't load this article",
     "emptySelectArticle": "Select an article to start reading",
     "emptyHintPrefix": "Press",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -158,6 +158,12 @@
   "reader": {
     "fullTextExtracted": "全文を抽出しました",
     "linkCopied": "リンクをコピーしました",
+    "ctxCopy": "コピー",
+    "ctxSaveImage": "画像を保存",
+    "ctxCopyImageAddress": "画像アドレスをコピー",
+    "textCopied": "コピーしました",
+    "imageAddressCopied": "画像アドレスをコピーしました",
+    "imageSaveFailed": "画像を保存できませんでした",
     "loadError": "この記事を読み込めませんでした",
     "emptySelectArticle": "記事を選択して読み始める",
     "emptyHintPrefix": "押す",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -158,6 +158,12 @@
   "reader": {
     "fullTextExtracted": "已提取全文",
     "linkCopied": "链接已复制",
+    "ctxCopy": "复制",
+    "ctxSaveImage": "保存图片",
+    "ctxCopyImageAddress": "复制图片地址",
+    "textCopied": "已复制",
+    "imageAddressCopied": "图片地址已复制",
+    "imageSaveFailed": "图片保存失败",
     "loadError": "无法加载这篇文章",
     "emptySelectArticle": "选择一篇文章开始阅读",
     "emptyHintPrefix": "按",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -23,25 +23,13 @@ document.documentElement.dataset.platform = isMac ? "mac" : "other";
 
 // Suppress the webview's default context menu — its "Reload / Back / Inspect"
 // entries belong to a browser, not a finished app. Editable surfaces still get
-// the native menu so paste / select-all / spellcheck stay available.
-//
-// Two reader cases also keep the native menu, because there the webview offers
-// genuinely useful, content-only entries (no Reload/Back/Inspect): a right-click
-// on an article image (Save Image / Copy Image / Copy Image Address) and a
-// right-click over a text selection (Copy / Look Up / Translate). Everywhere
-// else the app's own context menu takes over.
+// the native menu so paste / select-all / spellcheck stay available. The reader
+// supplies its own context menu (copy / save image / …) in ContextMenu.tsx.
 window.addEventListener("contextmenu", (e) => {
   const t = e.target as HTMLElement | null;
   if (t?.closest("input, textarea, [contenteditable=''], [contenteditable='true']")) return;
-  if (t?.closest(".reader-content") && (t.closest("img") || hasSelection())) return;
   e.preventDefault();
 });
-
-/** Whether the user currently has a non-collapsed text selection. */
-function hasSelection(): boolean {
-  const sel = window.getSelection();
-  return !!sel && !sel.isCollapsed && sel.toString().trim().length > 0;
-}
 
 const queryClient = new QueryClient({
   defaultOptions: {


### PR DESCRIPTION
#7 的方案调整(承接已合并的 #17)。

## 背景
#17 当时让正文图片/选区**放行 webview 原生菜单**来提供"复制/保存图片"。但原生菜单**无法裁剪**:
- 开发构建里会暴露 "Inspect Element"(等于打开控制台);
- 即便 release 没有 Inspect,选区菜单仍带"查询/翻译/共享"、图片菜单带"在新窗口打开图像/添加到照片图库"等无法移除的系统项。

这与本 app"全局刻意隐藏浏览器式菜单"的设计相悖。

## 改动
改为在 reader 自有的 `ContextMenu` 里加条目,菜单完全可控、风格统一:
- 右键**图片** → 保存图片 / 复制图片地址;
- 右键**选中文字** → 复制;
- 其后接原有的 AI 摘要 / 翻译 / 复制链接 / 专注模式。

`main.tsx` 恢复为"除输入框外一律屏蔽原生菜单"。

**保存图片**:新增后端命令 `fetch_image`,在 Rust 侧取图(带浏览器 UA、**不带 Referer**,绕开 `*.sinaimg.cn` 等防盗链——与 #9 让图片能显示的原理一致),再用 app 既有的 blob-anchor 机制下载;带 25MB 上限。

## 文件
- `commands.rs` / `lib.rs` — `fetch_image` 命令 + 注册
- `Reader.tsx` — 右键捕获图片/选区,菜单条目,`saveImage`/`copyText`
- `lib/download.ts` — `downloadBlob` + `imageFilename`
- `api.ts` — `fetchImage`
- `locales/{en,zh,ja}.json` — 文案

## 验证
- `cargo build`、`tsc --noEmit`、`vitest`(60)全过;
- 在 `tauri dev` 中实测:右键图片/选区弹出 app 菜单,保存图片可下载、复制地址/复制文字可用,全程无原生菜单。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Enhanced right-click context menu in the article reader with new options: copy selected text, save images to your device, and copy image URLs to the clipboard
- Added full localization support for new context menu labels in English, Japanese, and Chinese

<!-- end of auto-generated comment: release notes by coderabbit.ai -->