### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "papr",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "papr"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "papr"
-version = "0.5.0"
+version = "0.6.0"
 description = "Papr — a modern RSS reader"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Papr",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "identifier": "com.thomas.papr",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Bump version to 0.6.0，为发布做准备。

自 v0.5.0 以来累积的变更：
- feat(reader): 自绘右键菜单，复制/保存图片 (#7, #17, #18)
- fix(reader): 无 Referer 加载图片，绕过防盗链 (#9, #16)
- fix(sync): 映射 FreshRSS/GReader 文件夹到本地文件夹 (#5, #15)
- fix(opml): 容忍导入文件中未转义的 & (#14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application version to 0.6.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->