### PR TITLE
fix(reader): recover hotlink-blocked images via backend Referer fallbacks

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -407,32 +407,71 @@ const IMAGE_UA: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) \
 /// memory. Well above any real article image.
 const MAX_IMAGE_BYTES: u64 = 25 * 1024 * 1024;
 
-/// Fetch a feed image's bytes for the reader's "Save image" action.
+/// The `Referer` values to try, in order, when fetching an image. Hotlink
+/// protection cuts both ways: blacklist hosts (`*.sinaimg.cn`) 403 a foreign
+/// Referer but serve a bare request, while others (`cdnfile.sspai.com`) 403 a
+/// bare request and demand a Referer be present; strict whitelist CDNs accept
+/// only their own site — which the article URL satisfies. No single value
+/// works everywhere, so the fetch walks this chain until one succeeds.
+fn referer_candidates(image_url: &str, page_url: Option<&str>) -> Vec<Option<String>> {
+    let mut out = vec![None];
+    if let Ok(u) = Url::parse(image_url) {
+        let origin = u.origin().ascii_serialization();
+        if origin != "null" {
+            out.push(Some(format!("{origin}/")));
+        }
+    }
+    if let Some(p) = page_url {
+        if (p.starts_with("http://") || p.starts_with("https://")) && Url::parse(p).is_ok() {
+            let candidate = Some(p.to_string());
+            if !out.contains(&candidate) {
+                out.push(candidate);
+            }
+        }
+    }
+    out
+}
+
+/// Fetch a feed image's bytes — for the reader's "Save image" action and as
+/// the retry path for images the webview itself failed to load.
 ///
-/// Done in Rust rather than via the webview so the request can omit the
-/// `Referer` that hotlink-protected hosts (notably `*.sinaimg.cn` behind
-/// 喷嚏图卦) reject — the same workaround that lets these images render at all
-/// (see `sanitize`). The frontend wraps the returned bytes in a download.
+/// Done in Rust rather than via the webview so the request's `Referer` can be
+/// controlled: it walks [`referer_candidates`] (none → image origin → article
+/// URL) until the host serves the image, which covers both blacklist- and
+/// whitelist-style hotlink protection. `page_url` is the article's link, used
+/// as the final candidate. Transport errors abort the chain — a different
+/// Referer can't fix an unreachable host — only HTTP status errors advance it.
 #[tauri::command]
-pub async fn fetch_image(state: State<'_, AppState>, url: String) -> AppResult<tauri::ipc::Response> {
+pub async fn fetch_image(
+    state: State<'_, AppState>,
+    url: String,
+    page_url: Option<String>,
+) -> AppResult<tauri::ipc::Response> {
     if !(url.starts_with("http://") || url.starts_with("https://")) {
         return Err(AppError::code("badImageUrl"));
     }
     let http = state.http();
-    let resp = http
-        .get(&url)
-        .header("User-Agent", IMAGE_UA)
-        .send()
-        .await?
-        .error_for_status()?;
-    if resp.content_length().is_some_and(|n| n > MAX_IMAGE_BYTES) {
-        return Err(AppError::code("imageTooLarge"));
+    let mut last_err = AppError::code("badImageUrl");
+    for referer in referer_candidates(&url, page_url.as_deref()) {
+        let mut req = http.get(&url).header("User-Agent", IMAGE_UA);
+        if let Some(r) = &referer {
+            req = req.header("Referer", r.as_str());
+        }
+        match req.send().await?.error_for_status() {
+            Err(e) => last_err = e.into(),
+            Ok(resp) => {
+                if resp.content_length().is_some_and(|n| n > MAX_IMAGE_BYTES) {
+                    return Err(AppError::code("imageTooLarge"));
+                }
+                let bytes = resp.bytes().await?;
+                if bytes.len() as u64 > MAX_IMAGE_BYTES {
+                    return Err(AppError::code("imageTooLarge"));
+                }
+                return Ok(tauri::ipc::Response::new(bytes.to_vec()));
+            }
+        }
     }
-    let bytes = resp.bytes().await?;
-    if bytes.len() as u64 > MAX_IMAGE_BYTES {
-        return Err(AppError::code("imageTooLarge"));
-    }
-    Ok(tauri::ipc::Response::new(bytes.to_vec()))
+    Err(last_err)
 }
 
 // ─────────────────────────── OPML ───────────────────────────
@@ -1276,4 +1315,52 @@ pub async fn set_highlight_color(
 pub async fn delete_highlight(state: State<'_, AppState>, id: i64) -> AppResult<()> {
     let conn = state.db.lock().await;
     db::delete_highlight(&conn, id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- referer_candidates: the Referer fallback chain for image fetches. ---
+
+    #[test]
+    fn referer_candidates_tries_bare_then_origin_then_page() {
+        // Order matters: no Referer defeats blacklist-style protection
+        // (*.sinaimg.cn), the image's own origin satisfies hosts that demand a
+        // Referer be present (cdnfile.sspai.com), and the article URL is what
+        // a strict whitelist CDN expects.
+        let got = referer_candidates(
+            "https://cdnfile.sspai.com/2025/a.png?imageMogr2/thumbnail",
+            Some("https://sspai.com/post/110992"),
+        );
+        assert_eq!(
+            got,
+            vec![
+                None,
+                Some("https://cdnfile.sspai.com/".to_string()),
+                Some("https://sspai.com/post/110992".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn referer_candidates_without_page_url() {
+        let got = referer_candidates("https://wx1.sinaimg.cn/large/a.jpg", None);
+        assert_eq!(got, vec![None, Some("https://wx1.sinaimg.cn/".to_string())]);
+    }
+
+    #[test]
+    fn referer_candidates_skips_non_http_page_url() {
+        // A feed can ship anything as the article link; only an http(s) URL
+        // is a plausible Referer.
+        let got = referer_candidates("https://ex.com/a.png", Some("mailto:editor@ex.com"));
+        assert_eq!(got, vec![None, Some("https://ex.com/".to_string())]);
+    }
+
+    #[test]
+    fn referer_candidates_dedupes_page_equal_to_origin() {
+        // Article link identical to the image origin would be a wasted retry.
+        let got = referer_candidates("https://ex.com/a.png", Some("https://ex.com/"));
+        assert_eq!(got, vec![None, Some("https://ex.com/".to_string())]);
+    }
 }

--- a/src-tauri/src/sanitize.rs
+++ b/src-tauri/src/sanitize.rs
@@ -22,7 +22,9 @@ pub fn sanitize(html: &str, base: Option<&str>) -> String {
         // served. Without this the image silently fails to load (and the
         // reader then hides the broken `<img>`), so the article looks
         // text-only. Forcing the attribute on every `<img>` also overrides any
-        // weaker policy the feed shipped.
+        // weaker policy the feed shipped. Hosts that instead *require* a
+        // Referer (e.g. `cdnfile.sspai.com`) are covered by the reader's
+        // retry-through-backend path — see `commands::fetch_image`.
         .set_tag_attribute_value("img", "referrerpolicy", "no-referrer");
 
     let parsed_base = base.and_then(|b| Url::parse(b).ok());

--- a/src/api.ts
+++ b/src/api.ts
@@ -32,10 +32,13 @@ export const deleteFolder = (id: number) =>
   invoke<void>("delete_folder", { id });
 
 // ── images ──
-/** Fetch an image's raw bytes via the backend (no Referer, to defeat hotlink
- *  protection) for the reader's "Save image" action. Returns the bytes. */
-export const fetchImage = (url: string) =>
-  invoke<ArrayBuffer>("fetch_image", { url });
+/** Fetch an image's raw bytes via the backend, which walks Referer fallbacks
+ *  (none → image origin → article URL) until the host serves it — hotlink
+ *  protection demands different Referers on different hosts. Used by the
+ *  reader's "Save image" action and to retry images the webview itself failed
+ *  to load. `pageUrl` is the embedding article's link. */
+export const fetchImage = (url: string, pageUrl?: string | null) =>
+  invoke<ArrayBuffer>("fetch_image", { url, pageUrl: pageUrl ?? null });
 
 // ── feeds ──
 export const listFeeds = () => invoke<Feed[]>("list_feeds");

--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -167,6 +167,16 @@ export default function Reader({ onToast }: Props) {
     selection?: string;
   } | null>(null);
   const [heroBroken, setHeroBroken] = useState(false);
+  // blob: URL of a hero image recovered through the backend after the webview
+  // failed to load it directly (see the body-image retry effect below).
+  const [heroBlob, setHeroBlob] = useState<string | null>(null);
+  // Release the previous hero blob whenever it's replaced or cleared, and on
+  // unmount — object URLs otherwise live until the page does.
+  useEffect(() => {
+    return () => {
+      if (heroBlob) URL.revokeObjectURL(heroBlob);
+    };
+  }, [heroBlob]);
   const [progress, setProgress] = useState(0);
   const scrollRef = useRef<HTMLDivElement>(null);
   const bodyRef = useRef<HTMLDivElement>(null);
@@ -197,31 +207,61 @@ export default function Reader({ onToast }: Props) {
     setScrolled(false);
     setTagPick(null);
     setHeroBroken(false);
+    setHeroBlob(null);
     setProgress(0);
     scrollMarkedRef.current = null;
     if (scrollRef.current) scrollRef.current.scrollTop = 0;
   }, [id]);
 
-  // Hide article-body images that fail to load — a broken-image icon in the
-  // middle of an article is just noise. Runs whenever the body changes
-  // (article switch, extract toggle, extraction finishing).
+  // Recover article-body images the webview fails to load, then hide the
+  // stragglers. The webview sends no Referer (see sanitize.rs) — right for
+  // blacklist-style hotlink protection (*.sinaimg.cn) but fatal on hosts that
+  // *require* one (cdnfile.sspai.com 403s a bare request), and the webview
+  // can't vary the value per host. So a failed image gets one retry through
+  // the backend, which walks Referer fallbacks (fetch_image) and returns the
+  // bytes; the <img> is swapped to a blob: URL, with the original kept in
+  // data-papr-src for the context-menu actions. Images the backend can't
+  // recover are hidden — a broken-image icon mid-article is just noise. Runs
+  // whenever the body changes (article switch, extract toggle, extraction
+  // finishing).
   useEffect(() => {
     const el = bodyRef.current;
     if (!el) return;
-    const hide = (e: Event) => {
-      (e.currentTarget as HTMLElement).style.display = "none";
+    const pageUrl = a?.url;
+    const blobs: string[] = [];
+    let alive = true;
+    const recover = async (img: HTMLImageElement) => {
+      const src = img.getAttribute("src") || "";
+      if (img.dataset.paprRetried || !/^https?:\/\//.test(src)) {
+        img.style.display = "none";
+        return;
+      }
+      img.dataset.paprRetried = "1";
+      try {
+        const buf = await api.fetchImage(src, pageUrl);
+        if (!alive) return;
+        const blob = URL.createObjectURL(new Blob([buf]));
+        blobs.push(blob);
+        img.dataset.paprSrc = src;
+        img.src = blob;
+      } catch {
+        img.style.display = "none";
+      }
     };
+    const onError = (e: Event) => void recover(e.currentTarget as HTMLImageElement);
     const watched: HTMLImageElement[] = [];
     el.querySelectorAll("img").forEach((img) => {
-      if (img.complete && img.naturalWidth === 0) {
-        img.style.display = "none";
-      } else {
-        img.addEventListener("error", hide);
-        watched.push(img);
-      }
+      img.addEventListener("error", onError);
+      watched.push(img);
+      // Already failed before this effect attached its listener.
+      if (img.complete && img.naturalWidth === 0) void recover(img);
     });
-    return () => watched.forEach((img) => img.removeEventListener("error", hide));
-  }, [a?.id, showExtracted, a?.extractedHtml, showTranslation, a?.translatedHtml]);
+    return () => {
+      alive = false;
+      watched.forEach((img) => img.removeEventListener("error", onError));
+      blobs.forEach((b) => URL.revokeObjectURL(b));
+    };
+  }, [a?.id, a?.url, showExtracted, a?.extractedHtml, showTranslation, a?.translatedHtml]);
 
   // Mark as read once when an unread article is opened (if the user opted in).
   useEffect(() => {
@@ -344,12 +384,12 @@ export default function Reader({ onToast }: Props) {
     navigator.clipboard.writeText(text).then(() => onToast(t(toastKey)), () => {});
   };
   // Save a feed image to disk. The bytes are fetched in Rust (not the webview)
-  // so the request carries no Referer — the same hotlink workaround that lets
-  // these images render at all (see sanitize.rs). The download itself reuses
-  // the app's blob-anchor mechanism.
+  // so the request's Referer can walk the same hotlink-protection fallbacks
+  // that let these images render at all (see fetch_image). The download itself
+  // reuses the app's blob-anchor mechanism.
   const saveImage = async (url: string) => {
     try {
-      const buf = await api.fetchImage(url);
+      const buf = await api.fetchImage(url, a?.url);
       downloadBlob(new Blob([buf]), imageFilename(url));
     } catch {
       toast.error(t("reader.imageSaveFailed"));
@@ -576,14 +616,16 @@ export default function Reader({ onToast }: Props) {
           // Capture what the click landed on so the menu can add image- and
           // selection-specific actions (the native menu is suppressed app-wide;
           // see main.tsx).
-          const img = (e.target as HTMLElement).closest("img");
+          const img = (e.target as HTMLElement).closest("img") as HTMLImageElement | null;
           const sel = window.getSelection();
           const selection =
             sel && !sel.isCollapsed ? sel.toString().trim() : "";
           setCtxMenu({
             x: e.clientX,
             y: e.clientY,
-            imageUrl: (img as HTMLImageElement | null)?.currentSrc || img?.getAttribute("src") || undefined,
+            // data-papr-src holds the real address when the image was
+            // recovered through the backend and src is a blob: URL.
+            imageUrl: img?.dataset.paprSrc || img?.currentSrc || img?.getAttribute("src") || undefined,
             selection: selection || undefined,
           });
         }}
@@ -647,13 +689,37 @@ export default function Reader({ onToast }: Props) {
             // feeds that repeat their lead image don't show it twice.
             !body.includes(a.imageUrl) && (
               <img
-                src={a.imageUrl}
+                src={heroBlob ?? a.imageUrl}
                 alt=""
+                // The original URL when src is a recovered blob:, so the
+                // context-menu copy/save actions see a real address.
+                data-papr-src={heroBlob ? a.imageUrl : undefined}
                 // No Referer, for the same hotlink-protection reason feed-body
                 // images are sanitized this way (e.g. *.sinaimg.cn 403s a
                 // request carrying our origin). See `sanitize`.
                 referrerPolicy="no-referrer"
-                onError={() => setHeroBroken(true)}
+                // Same recovery as body images: hosts that *require* a Referer
+                // (cdnfile.sspai.com) 403 the direct load, so retry through
+                // the backend's Referer-fallback fetch before giving up.
+                onError={() => {
+                  // A failing blob: means the recovered bytes weren't a
+                  // renderable image — don't loop, give up.
+                  if (heroBlob) {
+                    setHeroBroken(true);
+                    return;
+                  }
+                  const articleId = a.id;
+                  api
+                    .fetchImage(a.imageUrl!, a.url)
+                    .then((buf) => {
+                      if (useUi.getState().selectedArticleId !== articleId) return;
+                      setHeroBlob(URL.createObjectURL(new Blob([buf])));
+                    })
+                    .catch(() => {
+                      if (useUi.getState().selectedArticleId !== articleId) return;
+                      setHeroBroken(true);
+                    });
+                }}
               />
             )
           )}


### PR DESCRIPTION
#16 的后续，回应 [kanoshiou 的评论](https://github.com/l0ng-ai/papr/pull/16#issuecomment-4687368096)：`no-referrer` 没有在根源上解决问题，仍有静态资源强制要求 Referer（如少数派 `cdnfile.sspai.com`）。

## 根因（已实测确认）

#16 给所有图片加 `referrerpolicy="no-referrer"`，对**黑名单式**防盗链（新浪 `*.sinaimg.cn`：403 外站 Referer、放行空 Referer）有效；但防盗链还有相反的一类——**要求请求必须携带 Referer**。实测 `cdnfile.sspai.com` 上的真实图片：

| 请求 | 结果 |
|---|---|
| 无 Referer | **403** |
| `Referer: https://sspai.com/` | 200 |
| `Referer: https://example.com/`（任意外站） | 200 |

而 `<img>` 在 webview 里只能控制 Referer 的"发 / 不发"，无法按主机定制其值，所以单靠属性对这类主机无解。

## 改动

- **Rust `fetch_image`**（原"保存图片"命令）：改为沿 `referer_candidates` 链重试——无 Referer → 图片自身 origin → 文章链接——直到主机放行。无 Referer 一档照顾新浪类黑名单，origin / 文章链接两档照顾 referer-required 与白名单 CDN。传输层错误立即中止（换 Referer 救不了断网），仅 HTTP 状态错误推进链条。
- **Reader 正文图片**：webview 直载失败的 `<img>` 经后端按上述链取回字节，换成 `blob:` URL 显示；原始地址存入 `data-papr-src`，右键"保存图片 / 复制图片地址"读真实地址而非 `blob:`。后端也失败才隐藏（维持原有"不展示破图标"行为）。每图只重试一次，blob 随正文切换统一 revoke。
- **hero 大图**：同样接入重试，重试也失败才置 `heroBroken`。
- **保存图片**：带上文章链接，referer-required 主机上的图片现在也能保存。

## 为什么仍不是全量代理

#16 曾担心把全部图片流量绕经后端；本 PR 保留 webview 直载（含 `no-referrer`）作为快路径，**只有加载失败的图片**才走一次后端重试——常规流量零额外开销，两类防盗链都被覆盖。

## 测试

- 新增 `referer_candidates` 单测 4 例：链条顺序、缺省文章链接、非 http(s) 文章链接剔除、与 origin 去重。
- `cargo test` 201 passed；`pnpm build`（tsc + vite）与 `pnpm test`（60 passed）通过。
- curl 实测两类主机：`cdnfile.sspai.com` 空 Referer 403 / 任意 Referer 200；`tva1.sinaimg.cn` 外站 Referer 403 / 同源 Referer 放行——分别由链条不同档位命中。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic image recovery for failed loads: The reader now intelligently retries failed images through the backend with prioritized referer fallback strategies, significantly improving display reliability for images from sources requiring specific referer headers. This enhancement applies to all article images, including hero images and inline content images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->