### PR TITLE
Bump version to 0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "papr",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "papr"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "papr"
-version = "0.6.0"
+version = "0.6.1"
 description = "Papr — a modern RSS reader"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Papr",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "identifier": "com.thomas.papr",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
0.6.1 patch release:

- fix(opml): collapse duplicate feed URLs during import (#20)
- fix(reader): recover hotlink-blocked images via backend Referer fallbacks (#9) (#21)

合并后打 tag `v0.6.1` 触发 Release 构建。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.6.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->