### PR TITLE
feat(sources): support rsshub:// short links

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -65,6 +65,23 @@ pub async fn add_feed(
 ) -> AppResult<Feed> {
     let client = state.http();
 
+    // Step 0a: expand an `rsshub://route` short link into a normal feed URL on
+    // the configured RSSHub instance (default: the public rsshub.app). The
+    // expansion is a plain HTTP feed URL, so the rest of the pipeline handles
+    // it with no further special-casing. Only touch the DB when it's actually
+    // an rsshub link, so the common case pays nothing.
+    let url = if url.trim().get(..9).is_some_and(|s| s.eq_ignore_ascii_case("rsshub://")) {
+        let instance = {
+            let conn = state.db.lock().await;
+            db::get_setting(&conn, "rsshub_instance")?
+                .filter(|s| !s.trim().is_empty())
+                .unwrap_or_else(|| sources::DEFAULT_RSSHUB_INSTANCE.to_string())
+        };
+        sources::expand_rsshub(&url, &instance).unwrap_or(url)
+    } else {
+        url
+    };
+
     // Step 0: multi-source normalization. If the pasted URL is a known
     // special source, rewrite it to its real feed URL. A YouTube vanity URL
     // needs the channel page fetched to learn its channel id; that single

--- a/src-tauri/src/ingestion/sources.rs
+++ b/src-tauri/src/ingestion/sources.rs
@@ -81,6 +81,36 @@ pub fn youtube_feed_url(channel_id: &str) -> String {
     format!("https://www.youtube.com/feeds/videos.xml?channel_id={channel_id}")
 }
 
+/// The public RSSHub instance used when the user hasn't configured their own.
+pub const DEFAULT_RSSHUB_INSTANCE: &str = "https://rsshub.app";
+
+/// Expand an `rsshub://route` short link into a full feed URL on `instance`.
+///
+/// RSSHub documents routes in a scheme-style shorthand —
+/// `rsshub://github/issue/DIYgod/RSSHub` — that maps onto a normal HTTP feed
+/// at `<instance>/github/issue/DIYgod/RSSHub`. Once expanded the result is an
+/// ordinary RSS URL, so the caller can run it through the regular fetch/parse
+/// flow with no further special-casing.
+///
+/// Returns `None` for anything that isn't an `rsshub://` link (so callers fall
+/// through to the normal flow) or for an empty route. Pure, so it is unit
+/// tested without the network; the `instance` setting lookup lives in the
+/// caller, mirroring how the YouTube network fetch stays out of this module.
+pub fn expand_rsshub(input: &str, instance: &str) -> Option<String> {
+    let trimmed = input.trim();
+    // Schemes are case-insensitive; users paste `rsshub://` but tolerate any
+    // casing. "rsshub://" is pure ASCII, so byte-slicing past it is safe.
+    if !trimmed.get(..9)?.eq_ignore_ascii_case("rsshub://") {
+        return None;
+    }
+    let route = trimmed[9..].trim_start_matches('/');
+    if route.is_empty() {
+        return None;
+    }
+    let base = instance.trim().trim_end_matches('/');
+    Some(format!("{base}/{route}"))
+}
+
 /// True for the URL-safe id characters YouTube uses in channel/playlist ids:
 /// ASCII alphanumerics plus `_` and `-`.
 fn is_id_char(c: char) -> bool {
@@ -496,6 +526,44 @@ mod tests {
     #[test]
     fn garbage_input_untouched() {
         assert_eq!(normalize_source("not a url at all"), Normalized::Untouched);
+    }
+
+    // ── rsshub:// expansion ───────────────────────────────────────────
+
+    #[test]
+    fn expand_rsshub_maps_route_onto_instance() {
+        assert_eq!(
+            expand_rsshub("rsshub://github/issue/DIYgod/RSSHub", DEFAULT_RSSHUB_INSTANCE)
+                .as_deref(),
+            Some("https://rsshub.app/github/issue/DIYgod/RSSHub")
+        );
+    }
+
+    #[test]
+    fn expand_rsshub_honours_custom_self_hosted_instance() {
+        assert_eq!(
+            expand_rsshub("rsshub://bilibili/user/video/2267573", "https://rss.example.com/")
+                .as_deref(),
+            Some("https://rss.example.com/bilibili/user/video/2267573")
+        );
+    }
+
+    #[test]
+    fn expand_rsshub_is_case_insensitive_and_trims_slashes() {
+        // Scheme casing varies; leading route slashes and instance trailing
+        // slashes must not produce a doubled `//`.
+        assert_eq!(
+            expand_rsshub("  RSSHub:///telegram/channel/awesomeDIYgod  ", "https://rsshub.app")
+                .as_deref(),
+            Some("https://rsshub.app/telegram/channel/awesomeDIYgod")
+        );
+    }
+
+    #[test]
+    fn expand_rsshub_rejects_non_rsshub_and_empty_route() {
+        assert_eq!(expand_rsshub("https://rsshub.app/foo", DEFAULT_RSSHUB_INSTANCE), None);
+        assert_eq!(expand_rsshub("rsshub://", DEFAULT_RSSHUB_INSTANCE), None);
+        assert_eq!(expand_rsshub("rss", DEFAULT_RSSHUB_INSTANCE), None);
     }
 
     // ── channelId extraction ──────────────────────────────────────────

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -864,6 +864,7 @@ function SubscriptionsSection({
           </button>
         </div>
       </div>
+      <RsshubInstanceGroup />
       <div className="settings-group">
         <h3 className="settings-group-title">
           {t("settings.subscriptions.feedsCount", { count: filtered.length })}
@@ -900,6 +901,61 @@ function SubscriptionsSection({
         </div>
       </div>
     </>
+  );
+}
+
+/**
+ * RSSHub instance for expanding `rsshub://route` short links. Blank uses the
+ * public rsshub.app; self-hosters point it at their own instance. Persisted to
+ * the `rsshub_instance` setting that `add_feed` reads server-side.
+ */
+function RsshubInstanceGroup() {
+  const { t } = useTranslation();
+  const [value, setValue] = useState("");
+
+  useEffect(() => {
+    api
+      .getSetting("rsshub_instance")
+      .then((v) => setValue(v ?? ""))
+      .catch(() => {});
+  }, []);
+
+  const commit = () => {
+    api.setSetting("rsshub_instance", value.trim()).catch(() => {});
+  };
+
+  return (
+    <div className="settings-group" style={{ marginBottom: 18 }}>
+      <h3 className="settings-group-title">{t("settings.subscriptions.rsshubTitle")}</h3>
+      <Row
+        label={t("settings.subscriptions.rsshubInstance")}
+        desc={t("settings.subscriptions.rsshubInstanceDesc")}
+      >
+        <input
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") e.currentTarget.blur();
+          }}
+          placeholder="https://rsshub.app"
+          spellCheck={false}
+          autoCapitalize="off"
+          autoCorrect="off"
+          style={{
+            width: 220,
+            padding: "5px 9px",
+            borderRadius: 7,
+            border: "1px solid var(--hair-strong)",
+            background: "var(--panel)",
+            fontFamily: "inherit",
+            fontSize: 12.5,
+            color: "var(--ink)",
+            outline: 0,
+          }}
+        />
+      </Row>
+    </div>
   );
 }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -297,7 +297,10 @@
       "noMatch": "No matching feeds.",
       "opmlExported": "OPML exported to the Downloads folder",
       "opmlImported": "Imported {{count}} feeds from OPML",
-      "unsubscribed": "Unsubscribed from {{title}}"
+      "unsubscribed": "Unsubscribed from {{title}}",
+      "rsshubTitle": "RSSHub",
+      "rsshubInstance": "Instance",
+      "rsshubInstanceDesc": "Paste rsshub:// links to subscribe. Leave blank for the public rsshub.app, or point to your self-hosted instance."
     },
     "filters": {
       "title": "Filter rules",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -297,7 +297,10 @@
       "noMatch": "一致するフィードがありません。",
       "opmlExported": "OPML をダウンロードフォルダにエクスポートしました",
       "opmlImported": "OPML から {{count}} 件のフィードをインポートしました",
-      "unsubscribed": "{{title}} の購読を解除しました"
+      "unsubscribed": "{{title}} の購読を解除しました",
+      "rsshubTitle": "RSSHub",
+      "rsshubInstance": "インスタンス",
+      "rsshubInstanceDesc": "rsshub:// リンクを貼り付けて購読できます。空欄で公開インスタンス rsshub.app を使用、または自分でホストしたインスタンスを指定します。"
     },
     "filters": {
       "title": "フィルタールール",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -297,7 +297,10 @@
       "noMatch": "没有匹配的订阅源。",
       "opmlExported": "OPML 已导出到下载文件夹",
       "opmlImported": "已从 OPML 导入 {{count}} 个订阅源",
-      "unsubscribed": "已退订 {{title}}"
+      "unsubscribed": "已退订 {{title}}",
+      "rsshubTitle": "RSSHub",
+      "rsshubInstance": "实例地址",
+      "rsshubInstanceDesc": "粘贴 rsshub:// 链接即可订阅。留空使用公共的 rsshub.app，或填入你自托管的实例地址。"
     },
     "filters": {
       "title": "过滤规则",


### PR DESCRIPTION
## Goal

Closes #4. Support RSSHub's `rsshub://namespace/route/params` shorthand when adding a feed.

## Changes

- **`expand_rsshub`** (pure, unit-tested): expands `rsshub://github/issue/DIYgod/RSSHub` to `<instance>/github/issue/DIYgod/RSSHub`. Case-insensitive, trims route/instance slashes, returns `None` for non-rsshub input or an empty route.
- **`add_feed`**: expand the short link before normalisation; the result is a plain HTTP feed URL that flows through the existing fetch/parse path unchanged. The instance-setting lookup lives in `add_feed`, mirroring how the YouTube network resolution stays out of the sources module.
- **Settings UI**: a RSSHub instance field under Settings → Subscriptions (`rsshub_instance` setting). Blank uses the public `rsshub.app`; self-hosters point it at their own instance. en/zh/ja strings included.

## Verification

- `cargo test --lib`: 206 passed (incl. 4 `expand_rsshub` cases: default instance / self-hosted / case + slash normalisation / rejects invalid input).
- `tsc --noEmit` clean; `pnpm test` 60 passed; all three locale JSONs valid.

> Note: the public rsshub.app rate-limits some routes (observed 403) — exactly why the self-hosted instance setting matters; the expansion itself is unaffected.