### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "papr",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "papr"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "papr"
-version = "0.6.1"
+version = "0.7.0"
 description = "Papr — a modern RSS reader"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Papr",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "identifier": "com.thomas.papr",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
发布 0.7.0。

包含:
- feat: 支持 rsshub:// 短链订阅 (#4, #24)
- fix: FreshRSS/Miniflux 订阅本地→服务端推送,修复 Uncategorized 文件夹 (#10, #23)