### PR TITLE
feat(sidebar): add a "New folder" button to the feeds header

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -386,6 +386,23 @@ export default function Sidebar({
       onSubmit: (v) => guard(api.createTag(v), t("sidebar.toastTagCreated")),
     });
 
+  // Creating a folder only touches the folders list, which `refreshAfterBulk`
+  // (and thus `guard`) doesn't cover — invalidate it explicitly.
+  const createFolder = () =>
+    setPrompt({
+      title: t("app.newFolderTitle"),
+      initial: "",
+      placeholder: t("app.folderNamePlaceholder"),
+      onSubmit: (v) =>
+        api
+          .createFolder(v)
+          .then(() => {
+            qc.invalidateQueries({ queryKey: ["folders"] });
+            onToast(t("app.folderCreated"));
+          })
+          .catch((e) => reportError(e)),
+    });
+
   // Optimistically apply a new tag order, then persist; reconcile on either
   // outcome. Shared by the drag-reorder and the menu's move up/down.
   const persistTagOrder = (next: Tag[]) => {
@@ -519,13 +536,22 @@ export default function Sidebar({
 
         <div className="sb-section-title">
           <span>{t("sidebar.feeds")}</span>
-          <button
-            onClick={onAddFeed}
-            title={t("sidebar.addFeed")}
-            aria-label={t("sidebar.addFeed")}
-          >
-            <Icon name="plus" size={12} />
-          </button>
+          <span className="sb-section-actions">
+            <button
+              onClick={createFolder}
+              title={t("app.newFolderTitle")}
+              aria-label={t("app.newFolderTitle")}
+            >
+              <Icon name="folder" size={12} />
+            </button>
+            <button
+              onClick={onAddFeed}
+              title={t("sidebar.addFeed")}
+              aria-label={t("sidebar.addFeed")}
+            >
+              <Icon name="plus" size={12} />
+            </button>
+          </span>
         </div>
 
         {allFeeds.length === 0 && (

--- a/src/styles.css
+++ b/src/styles.css
@@ -235,6 +235,11 @@ button { font-family: inherit; }
   justify-content: space-between;
   white-space: nowrap;
 }
+.sb-section-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
 .sb-section-title button {
   background: none;
   border: 0;


### PR DESCRIPTION
## Summary

Closes #30.

Folder support — grouping feeds into folders, collapsing/expanding them (persisted), drag-to-move, rename and delete — is already fully implemented in the backend and sidebar. The only entry point for *creating* a folder, however, was the command palette (`new-folder`), which made the whole feature effectively invisible to users who don't know the palette exists. That's why the feature was reported as missing.

This PR surfaces the existing capability: it adds a folder button next to the existing add-feed (`+`) button in the **Feeds** section header, mirroring the new-tag button already present in the **Tags** section.

## Changes

- `src/components/Sidebar.tsx`: add a `createFolder` handler (prompt → `api.createFolder` → invalidate the `folders` query + toast) and a folder button in the feeds section header. Reuses the existing `app.newFolderTitle` / `app.folderNamePlaceholder` / `app.folderCreated` i18n strings (already present in en/zh/ja).
- `src/styles.css`: add a `.sb-section-actions` flex wrapper so the two header buttons sit together at the right edge.

## Notes

- `refreshAfterBulk` (used by the shared `guard` helper) only refreshes article caches, not the folders list, so `createFolder` invalidates the `folders` query explicitly.
- No backend, schema or API changes.

## Test

- `npx tsc --noEmit` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Create folders directly from the sidebar via a new dialog interface
  * Added "Create Folder" button in the feeds section for convenient folder management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->