### PR TITLE
docs: collapse the Homebrew install into a single command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ A fast, native RSS reader for the desktop.
 Install with [Homebrew](https://brew.sh):
 
 ```sh
-brew tap l0ng-ai/papr
-brew install --cask papr
+brew install --cask l0ng-ai/papr/papr
 ```
 
 ### All platforms


### PR DESCRIPTION
## Summary

The macOS install was two steps:

```sh
brew tap l0ng-ai/papr
brew install --cask papr
```

A fully-qualified cask name (`tap/cask`) makes `brew install` add the tap automatically, so the explicit `brew tap` line is redundant:

```sh
brew install --cask l0ng-ai/papr/papr
```

Docs-only change to README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated macOS Homebrew installation instructions to streamline the setup process. Users can now install the application with a single command instead of two separate steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->