### PR TITLE
Fix hotlink-protected feed images

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -52,6 +52,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "ammonia"
 version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1844,6 +1850,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashify"
@@ -2585,6 +2596,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lol_html"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00aad58f6ec3990e795943872f13651e7a5fa59dca2c8f31a74faf8a0e0fb652"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cssparser 0.36.0",
+ "encoding_rs",
+ "foldhash 0.2.0",
+ "hashbrown 0.17.1",
+ "memchr",
+ "mime",
+ "precomputed-hash",
+ "selectors 0.37.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3303,6 +3333,7 @@ dependencies = [
  "imap",
  "lettre",
  "log",
+ "lol_html",
  "mail-parser",
  "opml",
  "reqwest 0.12.28",
@@ -4297,6 +4328,25 @@ name = "selectors"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
+dependencies = [
+ "bitflags 2.11.1",
+ "cssparser 0.36.0",
+ "derive_more 2.1.1",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "precomputed-hash",
+ "rustc-hash",
+ "servo_arc",
+ "smallvec",
+]
+
+[[package]]
+name = "selectors"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cfaaa6035167f0e604e42723c7650d59ee269ef220d7bbe0565602c8a0173b9"
 dependencies = [
  "bitflags 2.11.1",
  "cssparser 0.36.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -54,6 +54,9 @@ mail-parser = "0.11"
 # content
 ammonia = "4.1.2"
 dom_smoothie = "0.17"
+# Rewrite lazy-loaded <img> tags (real URL in data-src/srcset) before ammonia
+# strips those attributes — see sanitize::promote_lazy_images.
+lol_html = "2"
 
 # "Send to Kindle" delivers the article as an email attachment (feature F8).
 # `rustls-tls` keeps the build self-contained (no system OpenSSL), matching the

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -413,15 +413,18 @@ pub async fn extract_fulltext(state: State<'_, AppState>, article_id: i64) -> Ap
     // Decode in the page's declared charset — a non-UTF-8 page (Shift-JIS,
     // GBK, ISO-8859-1, …) would otherwise become mojibake before Readability.
     let html = fetch::decode_html(&bytes, ct.as_deref());
+    let lead_image = extraction::lead_image(&html, &final_url);
 
     // Readability is not Send — run it on the blocking pool.
+    let extraction_url = final_url.clone();
     let extracted =
-        tokio::task::spawn_blocking(move || extraction::extract_article(&html, &final_url))
+        tokio::task::spawn_blocking(move || extraction::extract_article(&html, &extraction_url))
             .await
             .map_err(|e| AppError::other(format!("extraction task: {e}")))??;
+    let image_url = sanitize::first_image(&extracted).or(lead_image);
 
     let conn = state.db.lock().await;
-    db::set_extracted_html(&conn, article_id, &extracted)?;
+    db::set_extracted_html(&conn, article_id, &extracted, image_url.as_deref())?;
     Ok(extracted)
 }
 
@@ -477,7 +480,7 @@ pub async fn fetch_image(
     state: State<'_, AppState>,
     url: String,
     page_url: Option<String>,
-) -> AppResult<tauri::ipc::Response> {
+) -> AppResult<Vec<u8>> {
     if !(url.starts_with("http://") || url.starts_with("https://")) {
         return Err(AppError::code("badImageUrl"));
     }
@@ -498,7 +501,7 @@ pub async fn fetch_image(
                 if bytes.len() as u64 > MAX_IMAGE_BYTES {
                     return Err(AppError::code("imageTooLarge"));
                 }
-                return Ok(tauri::ipc::Response::new(bytes.to_vec()));
+                return Ok(bytes.to_vec());
             }
         }
     }

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -1065,23 +1065,36 @@ pub fn list_articles(
     Ok(rows)
 }
 
-/// Scan stored articles that have no thumbnail but whose body HTML embeds an
-/// image, returning the `(id, image_url)` pairs to adopt. Reads only — paired
-/// with `apply_card_images` so the caller can run this heavy parse on a reader
-/// connection and the quick writes under the writer lock. One-time: feeds
-/// ingested after the body-image fallback shipped already store this at parse.
+/// Scan stored articles that have no thumbnail but whose feed or extracted
+/// body HTML embeds an image, returning the `(id, image_url)` pairs to adopt.
+/// Reads only — paired with `apply_card_images` so the caller can run this
+/// heavy parse on a reader connection and the quick writes under the writer
+/// lock. One-time: feeds ingested after the body-image fallback shipped
+/// already store this at parse.
 pub fn card_image_backfill_scan(conn: &Connection) -> AppResult<Vec<(i64, String)>> {
     let mut stmt = conn.prepare(
-        "SELECT id, content_html FROM articles
-         WHERE image_url IS NULL AND content_html IS NOT NULL AND content_html <> ''",
+        "SELECT id, content_html, extracted_html FROM articles
+         WHERE image_url IS NULL
+           AND (
+                (content_html IS NOT NULL AND content_html <> '')
+                OR (extracted_html IS NOT NULL AND extracted_html <> '')
+           )",
     )?;
     let rows = stmt.query_map([], |r| {
-        Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?))
+        Ok((
+            r.get::<_, i64>(0)?,
+            r.get::<_, Option<String>>(1)?,
+            r.get::<_, Option<String>>(2)?,
+        ))
     })?;
     let mut out = Vec::new();
     for row in rows {
-        let (id, html) = row?;
-        if let Some(img) = crate::sanitize::first_image(&html) {
+        let (id, content_html, extracted_html) = row?;
+        let img = content_html
+            .as_deref()
+            .and_then(crate::sanitize::first_image)
+            .or_else(|| extracted_html.as_deref().and_then(crate::sanitize::first_image));
+        if let Some(img) = img {
             out.push((id, img));
         }
     }
@@ -1251,11 +1264,23 @@ pub fn set_read_later(conn: &Connection, id: i64, v: bool) -> AppResult<()> {
 /// Store the extracted full-text HTML and re-index the article's FTS body
 /// with it, so search covers the whole article rather than just the short
 /// summary the feed shipped.
-pub fn set_extracted_html(conn: &Connection, id: i64, html: &str) -> AppResult<()> {
+pub fn set_extracted_html(
+    conn: &Connection,
+    id: i64,
+    html: &str,
+    image_url: Option<&str>,
+) -> AppResult<()> {
     let tx = conn.unchecked_transaction()?;
     tx.execute(
-        "UPDATE articles SET extracted_html = ?2 WHERE id = ?1",
-        params![id, html],
+        "UPDATE articles
+            SET extracted_html = ?2,
+                image_url = CASE
+                    WHEN ?3 IS NOT NULL AND (image_url IS NULL OR trim(image_url) = '')
+                    THEN ?3
+                    ELSE image_url
+                END
+         WHERE id = ?1",
+        params![id, html, image_url],
     )?;
     tx.execute(
         "UPDATE articles_fts SET body = ?2 WHERE rowid = ?1",
@@ -2201,6 +2226,48 @@ mod tests {
         let after = get_article(&conn, id).unwrap();
         assert_eq!(after.translated_html.as_deref(), Some("<p>translation</p>"));
         assert_eq!(after.translated_lang.as_deref(), Some("en"));
+    }
+
+    #[test]
+    fn set_extracted_html_backfills_missing_image_url() {
+        let (conn, id) = test_db();
+        set_extracted_html(&conn, id, "<p>full text</p>", Some("https://ex.com/lead.jpg"))
+            .unwrap();
+
+        let after = get_article(&conn, id).unwrap();
+        assert_eq!(after.extracted_html.as_deref(), Some("<p>full text</p>"));
+        assert_eq!(after.image_url.as_deref(), Some("https://ex.com/lead.jpg"));
+    }
+
+    #[test]
+    fn set_extracted_html_keeps_existing_image_url() {
+        let (conn, id) = test_db();
+        conn.execute(
+            "UPDATE articles SET image_url = ?2 WHERE id = ?1",
+            params![id, "https://ex.com/feed.jpg"],
+        )
+        .unwrap();
+
+        set_extracted_html(&conn, id, "<p>full text</p>", Some("https://ex.com/lead.jpg"))
+            .unwrap();
+
+        let after = get_article(&conn, id).unwrap();
+        assert_eq!(after.image_url.as_deref(), Some("https://ex.com/feed.jpg"));
+    }
+
+    #[test]
+    fn card_image_backfill_scan_reads_extracted_html() {
+        let (conn, id) = test_db();
+        set_extracted_html(
+            &conn,
+            id,
+            r#"<p>full text</p><img src="https://ex.com/from-extracted.jpg">"#,
+            None,
+        )
+        .unwrap();
+
+        let updates = card_image_backfill_scan(&conn).unwrap();
+        assert_eq!(updates, vec![(id, "https://ex.com/from-extracted.jpg".into())]);
     }
 
     /// Compact `NewHighlight` builder for the highlight tests.

--- a/src-tauri/src/extraction.rs
+++ b/src-tauri/src/extraction.rs
@@ -5,6 +5,18 @@
 use crate::error::{AppError, AppResult};
 use crate::sanitize;
 use dom_smoothie::Readability;
+use scraper::{Html, Selector};
+use std::sync::LazyLock;
+use url::Url;
+
+static LEAD_IMAGE_SELECTORS: LazyLock<Selector> = LazyLock::new(|| {
+    Selector::parse(
+        r#"meta[property="og:image"], meta[name="og:image"],
+           meta[property="twitter:image"], meta[name="twitter:image"],
+           meta[itemprop="image"], link[rel="image_src"]"#,
+    )
+    .expect("lead image selector is valid")
+});
 
 /// Extract the main article HTML from a full web page, then sanitize it.
 /// `dom_smoothie`'s reader is not `Send`, so this stays fully synchronous —
@@ -20,4 +32,53 @@ pub fn extract_article(html: &str, url: &str) -> AppResult<String> {
         return Err(AppError::code("noExtractableContent"));
     }
     Ok(sanitize::sanitize(&content, Some(url)))
+}
+
+/// Pull a page-level lead image from metadata, resolving relative URLs against
+/// the final article URL. Summary-only feeds such as 少数派 often omit media
+/// fields in RSS, but the article page still exposes an `og:image`/Twitter
+/// image that can be used as the reader hero after full-text extraction.
+pub fn lead_image(html: &str, base: &str) -> Option<String> {
+    let doc = Html::parse_document(html);
+    doc.select(&LEAD_IMAGE_SELECTORS).find_map(|el| {
+        let raw = el
+            .value()
+            .attr("content")
+            .or_else(|| el.value().attr("href"))?
+            .trim();
+        resolve_http_url(raw, base)
+    })
+}
+
+fn resolve_http_url(raw: &str, base: &str) -> Option<String> {
+    if raw.is_empty() || raw.starts_with("data:") {
+        return None;
+    }
+    let url = Url::parse(raw)
+        .or_else(|_| Url::parse(base).and_then(|b| b.join(raw)))
+        .ok()?;
+    matches!(url.scheme(), "http" | "https").then(|| url.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::lead_image;
+
+    #[test]
+    fn lead_image_reads_og_image() {
+        let html = r#"<meta property="og:image" content="https://ex.com/a.jpg">"#;
+        assert_eq!(
+            lead_image(html, "https://site.test/post").as_deref(),
+            Some("https://ex.com/a.jpg")
+        );
+    }
+
+    #[test]
+    fn lead_image_resolves_relative_urls() {
+        let html = r#"<meta name="twitter:image" content="/img/a.jpg">"#;
+        assert_eq!(
+            lead_image(html, "https://site.test/post/1").as_deref(),
+            Some("https://site.test/img/a.jpg")
+        );
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -170,7 +170,7 @@ pub fn run() {
             tauri::async_runtime::spawn(async move {
                 let updates = tauri::async_runtime::spawn_blocking(move || {
                     let conn = db::open_reader(&bf_db_path).ok()?;
-                    if db::get_setting(&conn, "card_image_backfill")
+                    if db::get_setting(&conn, "card_image_backfill_v2")
                         .ok()
                         .flatten()
                         .is_some()
@@ -186,7 +186,7 @@ pub fn run() {
                 let state = bf_handle.state::<AppState>();
                 let conn = state.db.lock().await;
                 let _ = db::apply_card_images(&conn, &updates);
-                let _ = db::set_setting(&conn, "card_image_backfill", "1");
+                let _ = db::set_setting(&conn, "card_image_backfill_v2", "1");
             });
             Ok(())
         })

--- a/src-tauri/src/sanitize.rs
+++ b/src-tauri/src/sanitize.rs
@@ -3,6 +3,7 @@
 
 use ammonia::{Builder, UrlRelative};
 use ego_tree::iter::Edge;
+use lol_html::{element, rewrite_str, RewriteStrSettings};
 use scraper::node::Node;
 use scraper::{Html, Selector};
 use std::sync::LazyLock;
@@ -11,6 +12,13 @@ use url::Url;
 /// Sanitize untrusted HTML for safe rendering inside the reader webview.
 /// Relative URLs are rewritten against `base` so feed images/links resolve.
 pub fn sanitize(html: &str, base: Option<&str>) -> String {
+    // Recover lazy-loaded image URLs before ammonia runs: feeds that lazy-load
+    // (少数派/sspai, WeChat, many CMSes) put the real URL in `data-src`/`srcset`
+    // and leave `src` empty or a placeholder, and ammonia's default whitelist
+    // drops those attributes — so without this the `<img>` reaches the reader
+    // with no usable `src` and silently shows nothing. See `promote_lazy_images`.
+    let html = promote_lazy_images(html);
+
     let mut builder = Builder::default();
     builder
         .link_rel(Some("noopener noreferrer nofollow"))
@@ -31,7 +39,61 @@ pub fn sanitize(html: &str, base: Option<&str>) -> String {
     if let Some(b) = parsed_base {
         builder.url_relative(UrlRelative::RewriteWithBase(b));
     }
-    builder.clean(html).to_string()
+    builder.clean(&html).to_string()
+}
+
+/// Promote a lazy-loaded image's real URL into `src` so it survives `sanitize`.
+/// Lazy-loading feeds ship `<img src="" data-src="https://…">` (or a tiny
+/// `data:` placeholder in `src`, or only a `srcset`); ammonia's default img
+/// whitelist keeps `src` but drops `data-*`/`srcset`, which would leave an
+/// `<img>` with nothing to load. Filling `src` here lets the recovered URL flow
+/// through the rest of the pipeline unchanged — relative-URL rewriting, the
+/// forced `no-referrer` policy, the webview load, and the `fetch_image` Referer
+/// fallback that handles hosts like `cdnfile.sspai.com`. Runs before `clean`,
+/// so ammonia still has the final say on safety; a rewrite failure falls back
+/// to the original HTML.
+fn promote_lazy_images(html: &str) -> String {
+    let handler = element!("img", |el| {
+        let has_real_src = el.get_attribute("src").is_some_and(|s| {
+            let s = s.trim();
+            !s.is_empty() && !s.starts_with("data:")
+        });
+        if !has_real_src {
+            let recovered = [
+                "data-src",
+                "data-original",
+                "data-actualsrc",
+                "data-lazy-src",
+            ]
+            .iter()
+            .find_map(|a| el.get_attribute(a))
+            .or_else(|| {
+                // `srcset` is "url1 1x, url2 2x" / "url1 480w, …" — take the
+                // first candidate's URL.
+                el.get_attribute("srcset").and_then(|ss| {
+                    ss.split(',')
+                        .next()
+                        .and_then(|c| c.split_whitespace().next())
+                        .map(str::to_string)
+                })
+            });
+            if let Some(url) = recovered {
+                let url = url.trim();
+                if !url.is_empty() {
+                    let _ = el.set_attribute("src", url);
+                }
+            }
+        }
+        Ok(())
+    });
+    rewrite_str(
+        html,
+        RewriteStrSettings {
+            element_content_handlers: vec![handler],
+            ..Default::default()
+        },
+    )
+    .unwrap_or_else(|_| html.to_string())
 }
 
 /// Tags whose text content is dropped wholesale (it isn't human-readable copy).
@@ -40,10 +102,39 @@ const SKIP_TAGS: &[&str] = &["script", "style", "template", "noscript"];
 /// Block-level tags: their edges are word boundaries, so text on either side
 /// must not be allowed to run together (`</h1><p>` → "TitleBody").
 const BLOCK_TAGS: &[&str] = &[
-    "address", "article", "aside", "blockquote", "br", "caption", "dd", "div",
-    "dl", "dt", "figcaption", "figure", "footer", "h1", "h2", "h3", "h4", "h5",
-    "h6", "header", "hr", "li", "main", "nav", "ol", "p", "pre", "section",
-    "table", "td", "th", "tr", "ul",
+    "address",
+    "article",
+    "aside",
+    "blockquote",
+    "br",
+    "caption",
+    "dd",
+    "div",
+    "dl",
+    "dt",
+    "figcaption",
+    "figure",
+    "footer",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "header",
+    "hr",
+    "li",
+    "main",
+    "nav",
+    "ol",
+    "p",
+    "pre",
+    "section",
+    "table",
+    "td",
+    "th",
+    "tr",
+    "ul",
 ];
 
 /// Strip all markup from HTML, yielding collapsed plain text. Used for the
@@ -134,10 +225,7 @@ mod tests {
     #[test]
     fn block_boundaries_keep_words_apart() {
         // `</h1><p>` must not collapse to "TitleBody".
-        assert_eq!(
-            html_to_text("<h1>Title</h1><p>Body</p>"),
-            "Title Body"
-        );
+        assert_eq!(html_to_text("<h1>Title</h1><p>Body</p>"), "Title Body");
     }
 
     #[test]
@@ -148,10 +236,7 @@ mod tests {
 
     #[test]
     fn html_entities_are_decoded() {
-        assert_eq!(
-            html_to_text("<p>Tom &amp; Jerry</p>"),
-            "Tom & Jerry"
-        );
+        assert_eq!(html_to_text("<p>Tom &amp; Jerry</p>"), "Tom & Jerry");
         assert_eq!(html_to_text("caf&#233;"), "café");
         assert_eq!(html_to_text("a &lt;tag&gt; b"), "a <tag> b");
     }
@@ -205,7 +290,8 @@ mod tests {
 
     #[test]
     fn first_image_returns_the_first_absolute_img() {
-        let html = r#"<p>intro</p><img src="https://ex.com/a.png"><img src="https://ex.com/b.png">"#;
+        let html =
+            r#"<p>intro</p><img src="https://ex.com/a.png"><img src="https://ex.com/b.png">"#;
         assert_eq!(first_image(html).as_deref(), Some("https://ex.com/a.png"));
     }
 
@@ -214,7 +300,10 @@ mod tests {
         // A leftover relative src can't resolve (sanitize would have made real
         // ones absolute); a data: blob is an inline pixel, not a thumbnail.
         assert_eq!(first_image(r#"<img src="/local.png">"#), None);
-        assert_eq!(first_image(r#"<img src="data:image/png;base64,AAAA">"#), None);
+        assert_eq!(
+            first_image(r#"<img src="data:image/png;base64,AAAA">"#),
+            None
+        );
         assert_eq!(first_image("<p>no images here</p>"), None);
         assert_eq!(first_image(""), None);
     }
@@ -222,7 +311,10 @@ mod tests {
     #[test]
     fn first_image_falls_through_relative_to_next_absolute() {
         let html = r#"<img src="/rel.png"><img src="https://ex.com/real.jpg">"#;
-        assert_eq!(first_image(html).as_deref(), Some("https://ex.com/real.jpg"));
+        assert_eq!(
+            first_image(html).as_deref(),
+            Some("https://ex.com/real.jpg")
+        );
     }
 
     #[test]
@@ -250,13 +342,74 @@ mod tests {
 
     #[test]
     fn sanitize_rewrites_relative_urls_against_base() {
-        let out = sanitize(
-            "<img src=\"/pic.png\">",
-            Some("https://example.com/post/"),
-        );
+        let out = sanitize("<img src=\"/pic.png\">", Some("https://example.com/post/"));
         assert!(
             out.contains("https://example.com/pic.png"),
             "relative URL not rewritten: {out}"
         );
+    }
+
+    // --- promote_lazy_images: recover lazy-loaded <img> URLs before sanitize. ---
+
+    #[test]
+    fn promotes_data_src_to_src() {
+        // sspai and many CMSes ship the real URL in data-src with src empty;
+        // ammonia would otherwise drop data-src, leaving an unloadable <img>.
+        let out = sanitize(
+            r#"<img src="" data-src="https://cdnfile.sspai.com/a.jpg">"#,
+            None,
+        );
+        assert!(
+            out.contains(r#"src="https://cdnfile.sspai.com/a.jpg""#),
+            "data-src not promoted: {out}"
+        );
+    }
+
+    #[test]
+    fn promotes_srcset_first_candidate_when_no_src() {
+        let out = sanitize(
+            r#"<img srcset="https://ex.com/a.jpg 1x, https://ex.com/b.jpg 2x">"#,
+            None,
+        );
+        assert!(
+            out.contains(r#"src="https://ex.com/a.jpg""#),
+            "srcset not promoted: {out}"
+        );
+    }
+
+    #[test]
+    fn promotes_over_data_placeholder_src() {
+        // A 1px data: placeholder in src must not block promotion.
+        let out = sanitize(
+            r#"<img src="data:image/gif;base64,AAAA" data-original="https://ex.com/real.jpg">"#,
+            None,
+        );
+        assert!(out.contains(r#"src="https://ex.com/real.jpg""#), "{out}");
+        assert!(
+            !out.contains("data:image/gif"),
+            "placeholder survived: {out}"
+        );
+    }
+
+    #[test]
+    fn real_src_is_not_overwritten_by_data_src() {
+        let out = sanitize(
+            r#"<img src="https://ex.com/real.jpg" data-src="https://ex.com/other.jpg">"#,
+            None,
+        );
+        assert!(out.contains(r#"src="https://ex.com/real.jpg""#), "{out}");
+        assert!(
+            !out.contains("other.jpg"),
+            "data-src wrongly overrode src: {out}"
+        );
+    }
+
+    #[test]
+    fn promoted_image_still_gets_no_referrer() {
+        // The recovered src must still flow through the no-referrer policy that
+        // hotlink-protected hosts depend on.
+        let out = sanitize(r#"<img data-src="https://cdnfile.sspai.com/a.jpg">"#, None);
+        assert!(out.contains(r#"referrerpolicy="no-referrer""#), "{out}");
+        assert!(out.contains("cdnfile.sspai.com/a.jpg"), "{out}");
     }
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,7 @@
 // Thin typed wrappers over the Tauri command surface (src-tauri/src/commands.rs).
 
 import { invoke, Channel } from "@tauri-apps/api/core";
+import { imageBytes, type ImageBytesResponse } from "./lib/imageBytes";
 import type {
   AiEvent,
   ArticleDetail,
@@ -38,7 +39,9 @@ export const deleteFolder = (id: number) =>
  *  reader's "Save image" action and to retry images the webview itself failed
  *  to load. `pageUrl` is the embedding article's link. */
 export const fetchImage = (url: string, pageUrl?: string | null) =>
-  invoke<ArrayBuffer>("fetch_image", { url, pageUrl: pageUrl ?? null });
+  invoke<ImageBytesResponse>("fetch_image", { url, pageUrl: pageUrl ?? null }).then(
+    imageBytes,
+  );
 
 // ── feeds ──
 export const listFeeds = () => invoke<Feed[]>("list_feeds");

--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -30,6 +30,31 @@ function youtubeId(url: string | null): string | null {
   return m ? m[1] : null;
 }
 
+function needsImageProxy(src: string): boolean {
+  try {
+    const host = new URL(src).hostname.toLowerCase();
+    return host === "cdnfile.sspai.com" || host === "rssfile.sspai.com";
+  } catch {
+    return false;
+  }
+}
+
+function imageBlob(src: string, bytes: Uint8Array): Blob {
+  const path = src.split(/[?#]/, 1)[0]?.toLowerCase() ?? "";
+  const type = path.endsWith(".png")
+    ? "image/png"
+    : path.endsWith(".webp")
+      ? "image/webp"
+      : path.endsWith(".gif")
+        ? "image/gif"
+        : path.endsWith(".svg")
+          ? "image/svg+xml"
+          : path.endsWith(".jpg") || path.endsWith(".jpeg")
+            ? "image/jpeg"
+            : "";
+  return new Blob([bytes], type ? { type } : undefined);
+}
+
 /** Plain, entity-decoded text of an HTML body — for the reading-time estimate.
  *  A bare `replace(/<[^>]+>/g, " ")` tag-strip leaves HTML entities intact, so
  *  `Tom &amp; Jerry &mdash; done` would be counted as 5 words / 28 chars when
@@ -170,6 +195,10 @@ export default function Reader({ onToast }: Props) {
   // blob: URL of a hero image recovered through the backend after the webview
   // failed to load it directly (see the body-image retry effect below).
   const [heroBlob, setHeroBlob] = useState<string | null>(null);
+  const [proxiedBody, setProxiedBody] = useState<{
+    source: string;
+    html: string;
+  } | null>(null);
   // Release the previous hero blob whenever it's replaced or cleared, and on
   // unmount — object URLs otherwise live until the page does.
   useEffect(() => {
@@ -227,6 +256,7 @@ export default function Reader({ onToast }: Props) {
     if (!el) return;
     const pageUrl = a?.url;
     const blobs: string[] = [];
+    const timers: number[] = [];
     let alive = true;
     const recover = async (img: HTMLImageElement) => {
       const src = img.getAttribute("src") || "";
@@ -238,7 +268,7 @@ export default function Reader({ onToast }: Props) {
       try {
         const buf = await api.fetchImage(src, pageUrl);
         if (!alive) return;
-        const blob = URL.createObjectURL(new Blob([buf]));
+        const blob = URL.createObjectURL(imageBlob(src, buf));
         blobs.push(blob);
         img.dataset.paprSrc = src;
         img.src = blob;
@@ -246,20 +276,60 @@ export default function Reader({ onToast }: Props) {
         img.style.display = "none";
       }
     };
+    const recoverIfBroken = (img: HTMLImageElement) => {
+      if (img.dataset.paprRetried) return;
+      if (img.complete && img.naturalWidth === 0) void recover(img);
+    };
     const onError = (e: Event) => void recover(e.currentTarget as HTMLImageElement);
     const watched: HTMLImageElement[] = [];
     el.querySelectorAll("img").forEach((img) => {
       img.addEventListener("error", onError);
       watched.push(img);
-      // Already failed before this effect attached its listener.
-      if (img.complete && img.naturalWidth === 0) void recover(img);
+      // 少数派/CDN images reject the webview's bare no-referrer request. Proxy
+      // them immediately instead of waiting for WebKit to surface a load error.
+      if (needsImageProxy(img.getAttribute("src") || "")) {
+        void recover(img);
+      } else {
+        // Already failed before this effect attached its listener.
+        recoverIfBroken(img);
+      }
+    });
+    // WKWebView can finish a parser-inserted image before React's effect
+    // listener is attached, and in practice not every broken image reports
+    // that state synchronously. A few delayed sweeps make the fallback
+    // deterministic without retrying images that are still loading.
+    [250, 1000, 2500].forEach((delay) => {
+      timers.push(window.setTimeout(() => watched.forEach(recoverIfBroken), delay));
     });
     return () => {
       alive = false;
+      timers.forEach(window.clearTimeout);
       watched.forEach((img) => img.removeEventListener("error", onError));
       blobs.forEach((b) => URL.revokeObjectURL(b));
     };
   }, [a?.id, a?.url, showExtracted, a?.extractedHtml, showTranslation, a?.translatedHtml]);
+
+  // Same proactive proxy for the reader hero. These hosts need a Referer that
+  // only the Rust fetch path can provide; waiting for `onError` leaves a broken
+  // image visible in WKWebView on some builds.
+  useEffect(() => {
+    if (!a?.imageUrl || heroBlob || heroBroken || !needsImageProxy(a.imageUrl)) return;
+    let alive = true;
+    const articleId = a.id;
+    api
+      .fetchImage(a.imageUrl, a.url)
+      .then((buf) => {
+        if (!alive || useUi.getState().selectedArticleId !== articleId) return;
+        setHeroBlob(URL.createObjectURL(imageBlob(a.imageUrl!, buf)));
+      })
+      .catch(() => {
+        if (!alive || useUi.getState().selectedArticleId !== articleId) return;
+        setHeroBroken(true);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [a?.id, a?.imageUrl, a?.url, heroBlob, heroBroken]);
 
   // Mark as read once when an unread article is opened (if the user opted in).
   useEffect(() => {
@@ -299,6 +369,71 @@ export default function Reader({ onToast }: Props) {
   // articles can translate at once and switching away never interrupts one.
   const startTranslate = useTranslationJobs((s) => s.translate);
   const job = useTranslationJobs((s) => (id != null ? s.jobs[id] : undefined));
+
+  const hasExtracted = !!a?.extractedHtml;
+  const canTranslate = !!(a?.extractedHtml || a?.contentHtml);
+  const baseBody =
+    (showExtracted && a?.extractedHtml ? a.extractedHtml : a?.contentHtml) || "";
+  const jobForTarget = job && job.lang === targetLang ? job : undefined;
+  const translating = jobForTarget?.status === "translating";
+  const cachedValid = !!a?.translatedHtml && a.translatedLang === targetLang;
+  const translatedBody =
+    jobForTarget?.html || (cachedValid ? a?.translatedHtml ?? "" : "");
+  const hasTranslation = !!translatedBody;
+  const showToggle = hasTranslation || translating;
+  const body = showTranslation
+    ? translatedBody ||
+      (translating ? `<p><em>${t("reader.translating")}</em></p>` : baseBody)
+    : baseBody;
+  const displayBody = proxiedBody?.source === body ? proxiedBody.html : body;
+
+  // For hosts that require a Referer (notably 少数派's image CDN), proxy image
+  // URLs before injecting the HTML. This avoids relying on WKWebView's image
+  // error events for parser-inserted nodes, which are not reliable in release
+  // builds.
+  useEffect(() => {
+    if (!body) {
+      setProxiedBody(null);
+      return;
+    }
+    const doc = new DOMParser().parseFromString(body, "text/html");
+    const imgs = Array.from(doc.body.querySelectorAll("img")).filter((img) => {
+      const src = img.getAttribute("src") || "";
+      return /^https?:\/\//.test(src) && needsImageProxy(src);
+    });
+    if (imgs.length === 0) {
+      setProxiedBody(null);
+      return;
+    }
+
+    let alive = true;
+    const blobs: string[] = [];
+    Promise.all(
+      imgs.map(async (img) => {
+        const src = img.getAttribute("src") || "";
+        try {
+          const buf = await api.fetchImage(src, a?.url);
+          if (!alive) return;
+          const blob = URL.createObjectURL(imageBlob(src, buf));
+          blobs.push(blob);
+          img.dataset.paprSrc = src;
+          img.setAttribute("src", blob);
+          img.removeAttribute("srcset");
+          img.removeAttribute("referrerpolicy");
+        } catch {
+          if (!alive) return;
+          img.style.display = "none";
+        }
+      }),
+    ).then(() => {
+      if (alive) setProxiedBody({ source: body, html: doc.body.innerHTML });
+    });
+
+    return () => {
+      alive = false;
+      blobs.forEach((b) => URL.revokeObjectURL(b));
+    };
+  }, [body, a?.url]);
 
   // When a translation finishes, refetch the article so its persisted
   // `translatedHtml` lands in the cache — the toggle then keeps working after
@@ -477,33 +612,6 @@ export default function Reader({ onToast }: Props) {
     );
   }
 
-  const hasExtracted = !!a.extractedHtml;
-  const canTranslate = !!(a.extractedHtml || a.contentHtml);
-  const baseBody =
-    (showExtracted && a.extractedHtml ? a.extractedHtml : a.contentHtml) || "";
-
-  // A translation is "current" for this article only when it was produced for
-  // the active target language — a stale-language copy (cache or a job for a
-  // previously chosen language) is ignored so a re-translate kicks in instead.
-  const jobForTarget = job && job.lang === targetLang ? job : undefined;
-  const translating = jobForTarget?.status === "translating";
-  const cachedValid = !!a.translatedHtml && a.translatedLang === targetLang;
-  // Prefer the live job (grows per batch) so the translation streams in; fall
-  // back to the persisted copy when the article is reopened in a later session.
-  const translatedBody =
-    jobForTarget?.html || (cachedValid ? a.translatedHtml ?? "" : "");
-  const hasTranslation = !!translatedBody;
-  // The inline original/translation toggle appears once there is something to
-  // show or a translation is being produced.
-  const showToggle = hasTranslation || translating;
-  // In the translated view: show the translation when we have any, the
-  // "translating…" placeholder while a batch is still pending, and otherwise
-  // (e.g. the job errored) fall back to the original rather than a stuck spinner.
-  const body = showTranslation
-    ? translatedBody ||
-      (translating ? `<p><em>${t("reader.translating")}</em></p>` : baseBody)
-    : baseBody;
-
   const beginTranslate = () => {
     if (!canTranslate) return;
     if (!hasTranslation && !translating) startTranslate(a.id, targetLang);
@@ -581,7 +689,7 @@ export default function Reader({ onToast }: Props) {
           key={a.id}
           articleId={a.id}
           bodyRef={bodyRef}
-          bodyVersion={body}
+          bodyVersion={displayBody}
         />
         <div className="tb-btn spacer" />
         {a.url && (
@@ -780,7 +888,7 @@ export default function Reader({ onToast }: Props) {
             ref={bodyRef}
             onClick={makeLinkClickHandler(a.url)}
             dangerouslySetInnerHTML={{
-              __html: body || `<p><em>${t("reader.noContent")}</em></p>`,
+              __html: displayBody || `<p><em>${t("reader.noContent")}</em></p>`,
             }}
           />
         </article>

--- a/src/lib/imageBytes.test.ts
+++ b/src/lib/imageBytes.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { imageBytes } from "./imageBytes";
+
+describe("imageBytes", () => {
+  it("keeps Uint8Array responses as bytes", () => {
+    const bytes = new Uint8Array([0xff, 0xd8, 0xff]);
+    expect(imageBytes(bytes)).toBe(bytes);
+  });
+
+  it("wraps ArrayBuffer responses", () => {
+    const input = new Uint8Array([1, 2, 3]).buffer;
+    expect(Array.from(imageBytes(input))).toEqual([1, 2, 3]);
+  });
+
+  it("converts number-array IPC responses without stringifying", () => {
+    expect(Array.from(imageBytes([0xff, 0xd8, 0xff]))).toEqual([
+      0xff, 0xd8, 0xff,
+    ]);
+  });
+});

--- a/src/lib/imageBytes.ts
+++ b/src/lib/imageBytes.ts
@@ -1,0 +1,7 @@
+export type ImageBytesResponse = ArrayBuffer | Uint8Array | number[];
+
+export function imageBytes(data: ImageBytesResponse): Uint8Array {
+  if (data instanceof Uint8Array) return data;
+  if (data instanceof ArrayBuffer) return new Uint8Array(data);
+  return new Uint8Array(data);
+}


### PR DESCRIPTION
## Summary
- recover lazy-loaded image URLs before sanitization so `data-src`, `data-original`, and `srcset` images survive into reader HTML
- proactively proxy sspai CDN images through the backend and preserve original URLs for image actions
- backfill article card/hero images from extracted full text or page metadata when summary-only feeds omit media fields
- normalize image byte IPC responses on the frontend

## Verification
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `pnpm test`
- `pnpm build`
- manually checked current sspai feed/article image URLs: direct no-Referer CDN request returns 403, backend-style Referer requests return 200 image/png


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lead image extraction from article metadata (Open Graph, Twitter Card, etc.)
  * Implemented automatic promotion of lazy-loaded images for proper display
  * Added image proxying in reader view for improved loading reliability

* **Bug Fixes**
  * Enhanced image recovery from article content for better thumbnail extraction

* **Tests**
  * Added test coverage for image data handling and conversion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->