### PR TITLE
chore(window): nudge macOS traffic lights down

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
         "backgroundColor": "#F6F3EC",
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
-        "trafficLightPosition": { "x": 13, "y": 16 }
+        "trafficLightPosition": { "x": 13, "y": 19 }
       }
     ],
     "security": {


### PR DESCRIPTION
Move the macOS traffic-light controls down slightly (`trafficLightPosition.y` 16 → 19) for better vertical alignment with the toolbar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Fine-tuned window control button positioning on Windows for improved visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->