### PR TITLE
Bump version to 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "papr",
   "private": true,
-  "version": "0.7.1",
+  "version": "0.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "papr"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "papr"
-version = "0.7.1"
+version = "0.8.0"
 description = "Papr — a modern RSS reader"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Papr",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "identifier": "com.thomas.papr",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release v0.8.0.

Since v0.7.1:
- **feat(translate):** pluggable translation engines with per-article switching — Google / DeepL / Bing (keyless) alongside the LLM, default engine + language in Settings, inline per-article switchers (#40)
- **fix(reader,db):** recover hotlink-protected feed images, with dedup + blank-`image_url` backfill fixes (#41, integrates #38)
- **reader:** remove the reading-progress bar (#28)
- **chore(window):** nudge macOS traffic lights down (#42)

Bumps package.json / Cargo.toml / tauri.conf.json / Cargo.lock to 0.8.0. Merging then tagging `v0.8.0` triggers the release workflow (signed mac/Linux/Windows bundles + updater, draft GitHub Release).