### PR TITLE
fix(reader): keep recovered images alive across scroll

### DIFF
--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -10,6 +10,7 @@ import { useTranslationJobs } from "../translation";
 import { useArticleActions } from "../hooks/articleActions";
 import { renderMarkdown } from "../lib/markdown";
 import { downloadBlob, imageFilename } from "../lib/download";
+import { imageDataUrl } from "../lib/imageBytes";
 import { fullDate } from "../lib/feedMeta";
 import { isMac } from "../lib/platform";
 import { reportError, toast } from "../toast";
@@ -38,22 +39,6 @@ function needsImageProxy(src: string): boolean {
   } catch {
     return false;
   }
-}
-
-function imageBlob(src: string, bytes: Uint8Array): Blob {
-  const path = src.split(/[?#]/, 1)[0]?.toLowerCase() ?? "";
-  const type = path.endsWith(".png")
-    ? "image/png"
-    : path.endsWith(".webp")
-      ? "image/webp"
-      : path.endsWith(".gif")
-        ? "image/gif"
-        : path.endsWith(".svg")
-          ? "image/svg+xml"
-          : path.endsWith(".jpg") || path.endsWith(".jpeg")
-            ? "image/jpeg"
-            : "";
-  return new Blob([bytes], type ? { type } : undefined);
 }
 
 /** Plain, entity-decoded text of an HTML body — for the reading-time estimate.
@@ -193,20 +178,15 @@ export default function Reader({ onToast }: Props) {
     selection?: string;
   } | null>(null);
   const [heroBroken, setHeroBroken] = useState(false);
-  // blob: URL of a hero image recovered through the backend after the webview
-  // failed to load it directly (see the body-image retry effect below).
-  const [heroBlob, setHeroBlob] = useState<string | null>(null);
+  // data: URL of a hero image recovered through the backend after the webview
+  // failed to load it directly (see the body-image retry effect below). A data:
+  // URL (not blob:) so the bytes stay inline and survive the webview dropping
+  // blob backing data under memory pressure — the same fix as body images.
+  const [heroDataUrl, setHeroDataUrl] = useState<string | null>(null);
   const [proxiedBody, setProxiedBody] = useState<{
     source: string;
     html: string;
   } | null>(null);
-  // Release the previous hero blob whenever it's replaced or cleared, and on
-  // unmount — object URLs otherwise live until the page does.
-  useEffect(() => {
-    return () => {
-      if (heroBlob) URL.revokeObjectURL(heroBlob);
-    };
-  }, [heroBlob]);
   const scrollRef = useRef<HTMLDivElement>(null);
   const bodyRef = useRef<HTMLDivElement>(null);
   // Article id we already auto-marked read via scroll, so a flurry of scroll
@@ -236,7 +216,7 @@ export default function Reader({ onToast }: Props) {
     setScrolled(false);
     setTagPick(null);
     setHeroBroken(false);
-    setHeroBlob(null);
+    setHeroDataUrl(null);
     scrollMarkedRef.current = null;
     if (scrollRef.current) scrollRef.current.scrollTop = 0;
   }, [id]);
@@ -247,16 +227,18 @@ export default function Reader({ onToast }: Props) {
   // *require* one (cdnfile.sspai.com 403s a bare request), and the webview
   // can't vary the value per host. So a failed image gets one retry through
   // the backend, which walks Referer fallbacks (fetch_image) and returns the
-  // bytes; the <img> is swapped to a blob: URL, with the original kept in
-  // data-papr-src for the context-menu actions. Images the backend can't
-  // recover are hidden — a broken-image icon mid-article is just noise. Runs
-  // whenever the body changes (article switch, extract toggle, extraction
-  // finishing).
+  // bytes; the <img> is swapped to an inline data: URL, with the original kept
+  // in data-papr-src for the context-menu actions. A data: URL (not blob:) is
+  // deliberate — WKWebView/WebView2 silently drop a blob:'s backing data under
+  // memory pressure (e.g. layer recompositing while scrolling), so a recovered
+  // image carried by a blob: vanishes when the user scrolls away and back; the
+  // inline data: bytes always repaint. Images the backend can't recover are
+  // hidden — a broken-image icon mid-article is just noise. Runs whenever the
+  // body changes (article switch, extract toggle, extraction finishing).
   useEffect(() => {
     const el = bodyRef.current;
     if (!el) return;
     const pageUrl = a?.url;
-    const blobs: string[] = [];
     const timers: number[] = [];
     let alive = true;
     const recover = async (img: HTMLImageElement) => {
@@ -269,10 +251,8 @@ export default function Reader({ onToast }: Props) {
       try {
         const buf = await api.fetchImage(src, pageUrl);
         if (!alive) return;
-        const blob = URL.createObjectURL(imageBlob(src, buf));
-        blobs.push(blob);
         img.dataset.paprSrc = src;
-        img.src = blob;
+        img.src = imageDataUrl(src, buf);
       } catch {
         img.style.display = "none";
       }
@@ -287,7 +267,7 @@ export default function Reader({ onToast }: Props) {
       img.addEventListener("error", onError);
       watched.push(img);
       // Proxy-eligible images (少数派/CDN hosts that reject a bare no-referrer
-      // request) are rewritten to blob: URLs up front by the `proxiedBody`
+      // request) are rewritten to data: URLs up front by the `proxiedBody`
       // effect, so don't fetch them again here — that duplicated the backend /
       // IPC / network work for every matched image. `onError` above stays as a
       // fallback; this only retries an image that had already failed before the
@@ -305,7 +285,6 @@ export default function Reader({ onToast }: Props) {
       alive = false;
       timers.forEach(window.clearTimeout);
       watched.forEach((img) => img.removeEventListener("error", onError));
-      blobs.forEach((b) => URL.revokeObjectURL(b));
     };
   }, [a?.id, a?.url, showExtracted, a?.extractedHtml, showTranslation, a?.translatedHtml]);
 
@@ -313,14 +292,14 @@ export default function Reader({ onToast }: Props) {
   // only the Rust fetch path can provide; waiting for `onError` leaves a broken
   // image visible in WKWebView on some builds.
   useEffect(() => {
-    if (!a?.imageUrl || heroBlob || heroBroken || !needsImageProxy(a.imageUrl)) return;
+    if (!a?.imageUrl || heroDataUrl || heroBroken || !needsImageProxy(a.imageUrl)) return;
     let alive = true;
     const articleId = a.id;
     api
       .fetchImage(a.imageUrl, a.url)
       .then((buf) => {
         if (!alive || useUi.getState().selectedArticleId !== articleId) return;
-        setHeroBlob(URL.createObjectURL(imageBlob(a.imageUrl!, buf)));
+        setHeroDataUrl(imageDataUrl(a.imageUrl!, buf));
       })
       .catch(() => {
         if (!alive || useUi.getState().selectedArticleId !== articleId) return;
@@ -329,7 +308,7 @@ export default function Reader({ onToast }: Props) {
     return () => {
       alive = false;
     };
-  }, [a?.id, a?.imageUrl, a?.url, heroBlob, heroBroken]);
+  }, [a?.id, a?.imageUrl, a?.url, heroDataUrl, heroBroken]);
 
   // Mark as read once when an unread article is opened (if the user opted in).
   useEffect(() => {
@@ -409,7 +388,8 @@ export default function Reader({ onToast }: Props) {
   // For hosts that require a Referer (notably 少数派's image CDN), proxy image
   // URLs before injecting the HTML. This avoids relying on WKWebView's image
   // error events for parser-inserted nodes, which are not reliable in release
-  // builds.
+  // builds. The fetched bytes are inlined as data: URLs (not blob:) so they
+  // survive the webview dropping blob backing data while scrolling.
   useEffect(() => {
     if (!body) {
       setProxiedBody(null);
@@ -426,17 +406,14 @@ export default function Reader({ onToast }: Props) {
     }
 
     let alive = true;
-    const blobs: string[] = [];
     Promise.all(
       imgs.map(async (img) => {
         const src = img.getAttribute("src") || "";
         try {
           const buf = await api.fetchImage(src, a?.url);
           if (!alive) return;
-          const blob = URL.createObjectURL(imageBlob(src, buf));
-          blobs.push(blob);
           img.dataset.paprSrc = src;
-          img.setAttribute("src", blob);
+          img.setAttribute("src", imageDataUrl(src, buf));
           img.removeAttribute("srcset");
           img.removeAttribute("referrerpolicy");
         } catch {
@@ -450,7 +427,6 @@ export default function Reader({ onToast }: Props) {
 
     return () => {
       alive = false;
-      blobs.forEach((b) => URL.revokeObjectURL(b));
     };
   }, [body, a?.url]);
 
@@ -761,7 +737,7 @@ export default function Reader({ onToast }: Props) {
             x: e.clientX,
             y: e.clientY,
             // data-papr-src holds the real address when the image was
-            // recovered through the backend and src is a blob: URL.
+            // recovered through the backend and src is an inline data: URL.
             imageUrl: img?.dataset.paprSrc || img?.currentSrc || img?.getAttribute("src") || undefined,
             selection: selection || undefined,
           });
@@ -826,11 +802,11 @@ export default function Reader({ onToast }: Props) {
             // feeds that repeat their lead image don't show it twice.
             !body.includes(a.imageUrl) && (
               <img
-                src={heroBlob ?? a.imageUrl}
+                src={heroDataUrl ?? a.imageUrl}
                 alt=""
-                // The original URL when src is a recovered blob:, so the
+                // The original URL when src is a recovered data: URL, so the
                 // context-menu copy/save actions see a real address.
-                data-papr-src={heroBlob ? a.imageUrl : undefined}
+                data-papr-src={heroDataUrl ? a.imageUrl : undefined}
                 // No Referer, for the same hotlink-protection reason feed-body
                 // images are sanitized this way (e.g. *.sinaimg.cn 403s a
                 // request carrying our origin). See `sanitize`.
@@ -839,9 +815,9 @@ export default function Reader({ onToast }: Props) {
                 // (cdnfile.sspai.com) 403 the direct load, so retry through
                 // the backend's Referer-fallback fetch before giving up.
                 onError={() => {
-                  // A failing blob: means the recovered bytes weren't a
+                  // A failing data: URL means the recovered bytes weren't a
                   // renderable image — don't loop, give up.
-                  if (heroBlob) {
+                  if (heroDataUrl) {
                     setHeroBroken(true);
                     return;
                   }
@@ -850,7 +826,7 @@ export default function Reader({ onToast }: Props) {
                     .fetchImage(a.imageUrl!, a.url)
                     .then((buf) => {
                       if (useUi.getState().selectedArticleId !== articleId) return;
-                      setHeroBlob(URL.createObjectURL(new Blob([buf])));
+                      setHeroDataUrl(imageDataUrl(a.imageUrl!, buf));
                     })
                     .catch(() => {
                       if (useUi.getState().selectedArticleId !== articleId) return;

--- a/src/lib/imageBytes.test.ts
+++ b/src/lib/imageBytes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { imageBytes } from "./imageBytes";
+import { imageBytes, imageDataUrl, imageMime } from "./imageBytes";
 
 describe("imageBytes", () => {
   it("keeps Uint8Array responses as bytes", () => {
@@ -16,5 +16,57 @@ describe("imageBytes", () => {
     expect(Array.from(imageBytes([0xff, 0xd8, 0xff]))).toEqual([
       0xff, 0xd8, 0xff,
     ]);
+  });
+});
+
+describe("imageMime", () => {
+  it("detects PNG from its magic bytes regardless of URL", () => {
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
+    expect(imageMime("https://cdn.example/x", png)).toBe("image/png");
+  });
+
+  it("detects JPEG, GIF and WebP signatures", () => {
+    expect(imageMime("x", new Uint8Array([0xff, 0xd8, 0xff]))).toBe("image/jpeg");
+    expect(imageMime("x", new Uint8Array([0x47, 0x49, 0x46]))).toBe("image/gif");
+    const webp = new Uint8Array([
+      0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50,
+    ]);
+    expect(imageMime("x", webp)).toBe("image/webp");
+  });
+
+  it("trusts magic bytes over a misleading extension", () => {
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    expect(imageMime("https://cdn.example/photo.jpg", png)).toBe("image/png");
+  });
+
+  it("falls back to the extension when bytes are unrecognised", () => {
+    const junk = new Uint8Array([0, 1, 2, 3]);
+    expect(imageMime("https://cdn.example/a.png?v=2", junk)).toBe("image/png");
+    expect(imageMime("https://cdn.example/a.svg", junk)).toBe("image/svg+xml");
+    expect(imageMime("https://cdn.example/a.webp#frag", junk)).toBe("image/webp");
+  });
+
+  it("defaults to image/jpeg when nothing identifies the type", () => {
+    expect(imageMime("https://cdn.example/no-ext", new Uint8Array([0, 1, 2]))).toBe(
+      "image/jpeg",
+    );
+  });
+});
+
+describe("imageDataUrl", () => {
+  it("builds a base64 data: URL with the detected MIME", () => {
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    expect(imageDataUrl("https://cdn.example/x", png)).toBe(
+      `data:image/png;base64,${btoa("\x89PNG")}`,
+    );
+  });
+
+  it("encodes large inputs without overflowing the call stack", () => {
+    const big = new Uint8Array(200_000).fill(0x41); // 'A'
+    const url = imageDataUrl("https://cdn.example/big.jpg", big);
+    expect(url.startsWith("data:image/jpeg;base64,")).toBe(true);
+    // Round-trips back to the same bytes.
+    const decoded = atob(url.slice("data:image/jpeg;base64,".length));
+    expect(decoded.length).toBe(big.length);
   });
 });

--- a/src/lib/imageBytes.ts
+++ b/src/lib/imageBytes.ts
@@ -5,3 +5,69 @@ export function imageBytes(data: ImageBytesResponse): Uint8Array {
   if (data instanceof ArrayBuffer) return new Uint8Array(data);
   return new Uint8Array(data);
 }
+
+/** Detect an image's MIME type from its leading "magic" bytes, falling back to
+ *  the URL's file extension, and finally to image/jpeg. The type matters for a
+ *  data: URL: unlike a Blob (whose bytes the webview sniffs), a data: URL's
+ *  MIME is *declared*, so a wrong or empty type makes the <img> fail to render.
+ *  Many CDN image URLs carry no extension, which is why the byte sniff comes
+ *  first. */
+export function imageMime(src: string, bytes: Uint8Array): string {
+  const sniffed = sniffImageMime(bytes);
+  if (sniffed) return sniffed;
+  const path = src.split(/[?#]/, 1)[0]?.toLowerCase() ?? "";
+  if (path.endsWith(".png")) return "image/png";
+  if (path.endsWith(".webp")) return "image/webp";
+  if (path.endsWith(".gif")) return "image/gif";
+  if (path.endsWith(".svg")) return "image/svg+xml";
+  if (path.endsWith(".jpg") || path.endsWith(".jpeg")) return "image/jpeg";
+  return "image/jpeg";
+}
+
+/** MIME type from the byte signature, or null when none of the known image
+ *  formats match. SVG is text (no fixed magic bytes), so it is left to the
+ *  extension fallback in `imageMime`. */
+function sniffImageMime(b: Uint8Array): string | null {
+  // PNG: 89 50 4E 47
+  if (b.length >= 4 && b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4e && b[3] === 0x47)
+    return "image/png";
+  // JPEG: FF D8 FF
+  if (b.length >= 3 && b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff)
+    return "image/jpeg";
+  // GIF: "GIF"
+  if (b.length >= 3 && b[0] === 0x47 && b[1] === 0x49 && b[2] === 0x46)
+    return "image/gif";
+  // WebP: "RIFF"…"WEBP"
+  if (
+    b.length >= 12 &&
+    b[0] === 0x52 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x46 &&
+    b[8] === 0x57 && b[9] === 0x45 && b[10] === 0x42 && b[11] === 0x50
+  )
+    return "image/webp";
+  return null;
+}
+
+/** Encode recovered image bytes as a self-contained data: URL.
+ *
+ *  Images that fail to load directly (hotlink-protected hosts) are refetched
+ *  through the backend and re-injected here. A blob: URL would be the obvious
+ *  carrier, but WKWebView/WebView2 silently drop a blob:'s backing data under
+ *  memory pressure (e.g. layer recompositing while scrolling), so the recovered
+ *  image vanishes the moment the user scrolls away and back. A data: URL keeps
+ *  the bytes inline in the DOM, so the webview can always repaint it — and it
+ *  needs no revoke bookkeeping. */
+export function imageDataUrl(src: string, bytes: Uint8Array): string {
+  return `data:${imageMime(src, bytes)};base64,${bytesToBase64(bytes)}`;
+}
+
+/** Base64-encode bytes in chunks. A one-shot `String.fromCharCode(...bytes)`
+ *  spreads the whole array as arguments and overflows the call stack on large
+ *  images; chunking keeps each spread small. */
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+  }
+  return btoa(binary);
+}


### PR DESCRIPTION
## Problem

Closes #37.

Hotlink-protected images that the webview can't load directly (e.g. `cdnfile.sspai.com`, which **requires** a `Referer`) are recovered through the Rust backend and re-injected into the reader. Until now they were carried by `blob:` URLs.

WKWebView (macOS) and WebView2 (Windows) **silently drop a `blob:`'s backing data under memory pressure** — notably during the layer recompositing that scrolling triggers. So a recovered image rendered fine on first load, then **vanished the moment the user scrolled away and back**: the re-decode failed, the `error` handler saw `paprRetried` already set, and hid the `<img>` (`display: none`).

A secondary flicker: the effect-cleanup `revokeObjectURL` freed the blobs whenever the article data was refetched (e.g. on mark-as-read), so recovered images could blink out right after loading.

## Fix

Inline the recovered bytes as self-contained `data:` URLs instead of `blob:` URLs. The webview can always repaint a `data:` URL (the bytes live in the DOM), and there is no object-URL lifecycle to revoke — both the disappear-on-scroll and the flicker go away.

Applied to all three recovery paths:
- body-image `onError` retry
- proactive body image proxy (`proxiedBody`)
- the reader hero image

New helpers in `src/lib/imageBytes.ts`:
- `imageDataUrl(src, bytes)` — base64-encodes in chunks (avoids a call-stack overflow on large images).
- `imageMime(src, bytes)` — magic-byte sniffing (PNG/JPEG/GIF/WebP) with an extension fallback, since a `data:` URL must *declare* its MIME and many CDN image URLs carry no extension.

## Tests

Added unit tests for `imageMime` (signature detection, extension fallback, default) and `imageDataUrl` (correct output, large-input round-trip). `pnpm test` (70 passing) and `tsc --noEmit` both clean.

## Notes

CSP is `null` for the app window, so `data:` image URLs are unrestricted. `data:` URLs are slightly larger in memory than the raw bytes (base64 +33%), but this only affects the handful of hotlink-protected images that need recovery, not every image.