### PR TITLE
fix(theme): brighten muddy dark-mode highlight wash

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -77,7 +77,11 @@
   --selected: rgba(255, 248, 230, 0.07);
 
   --accent: oklch(0.74 0.13 45);
-  --accent-soft: oklch(0.32 0.06 40);
+  /* Highlight wash for selected rows, ::selection and active sidebar items.
+     The old oklch(0.32 0.06 40) (#4C271A) sat low and warm enough to read as a
+     muddy dried-blood brown; lifting it brighter and slightly more golden keeps
+     the terracotta identity while looking clean against the dark surfaces. */
+  --accent-soft: oklch(0.42 0.06 48);
   --accent-ink: oklch(0.80 0.10 45);
 
   --danger: oklch(0.68 0.16 28);


### PR DESCRIPTION
## Problem

In dark mode the highlight wash `--accent-soft` was `oklch(0.32 0.06 40)`, which renders as **`#4C271A`** — at that low lightness the warm terracotta hue reads as a muddy, dried-blood brown. It's used everywhere a row/region is highlighted: selected article (`.art.active`), `::selection`, active sidebar items, toolbar toggles, tag hover, etc., so the dingy cast shows up across the whole UI.

## Change

Lift it to `oklch(0.42 0.06 48)` (**`#684330`**) — brighter and slightly more golden. It keeps the terracotta identity that matches Papr's warm-paper aesthetic but reads clean against the dark surfaces, and makes the selected row noticeably more visible.

Only this one dark-theme variable changes; light mode and everything else are untouched.

## Notes

`#684330` is a touch more prominent on the very darkest shades (`data-dark-shade="black"`, `#000` paper). That was a conscious trade for visibility; happy to add a slightly dimmer `--accent-soft` override under the `black`/`dimmer` shade blocks if it feels too strong there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dark theme accent colors to improve visual contrast and appearance against dark surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->