### PR TITLE
fix(theme): dark-mode accent fixes — surfaces, highlight wash, text selection

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3335,6 +3335,8 @@ dependencies = [
  "log",
  "lol_html",
  "mail-parser",
+ "objc2",
+ "objc2-foundation",
  "opml",
  "reqwest 0.12.28",
  "rusqlite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -70,6 +70,14 @@ anyhow = "1"
 thiserror = "2"
 log = "0.4"
 
+# macOS-only: used in setup() to turn off the WKWebview's opaque white backing
+# (wry only does this under its `transparent` feature, which we don't enable),
+# so a live window resize stops flashing white. Versions track what tauri/wry
+# already pull in, keeping a single objc2 in the tree.
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+objc2-foundation = "0.3"
+
 [profile.release]
 codegen-units = 1
 lto = true

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -138,9 +138,9 @@ pub fn run() {
                 if let Some(win) = app.get_webview_window("main") {
                     // Match the dark-shade's `--paper` in styles.css / DARK_PAPER.
                     let (r, g, b) = match dark_shade.as_deref() {
-                        Some("dimmer") => (0x0E, 0x0C, 0x08),
+                        Some("dimmer") => (0x06, 0x05, 0x04),
                         Some("black") => (0x00, 0x00, 0x00),
-                        _ => (0x16, 0x14, 0x0F),
+                        _ => (0x0E, 0x0C, 0x0B),
                     };
                     let _ = win
                         .set_background_color(Some(tauri::window::Color(r, g, b, 0xFF)));

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -127,6 +127,36 @@ pub fn run() {
                 }
             }
 
+            // ── Kill the WKWebview's opaque white backing (macOS) ─────
+            // On macOS wry creates the WKWebview isOpaque=true / drawsBackground
+            // =true (a solid WHITE backing) and only turns that off under its
+            // `transparent` cargo feature — which we don't enable. So during a
+            // live window resize the webview's renderer lags the new size and
+            // the freshly-exposed strip shows that white backing. No CSS, html
+            // background, or NSWindow colour can cover it: the opaque webview
+            // layer composites ON TOP of the page. The only fix is to make the
+            // webview non-opaque so the (themed) NSWindow background shows
+            // through that strip instead. See tauri-apps/tauri#14288.
+            #[cfg(target_os = "macos")]
+            if let Some(win) = app.get_webview_window("main") {
+                let _ = win.with_webview(|webview| {
+                    use objc2::msg_send;
+                    use objc2::runtime::AnyObject;
+                    use objc2_foundation::{NSNumber, NSString};
+                    let wk = webview.inner() as *mut AnyObject;
+                    if !wk.is_null() {
+                        unsafe {
+                            let _: () = msg_send![wk, setOpaque: false];
+                            // `drawsBackground` is a private KVC key on WKWebView
+                            // — the same one wry toggles for transparent windows.
+                            let no = NSNumber::numberWithBool(false);
+                            let key = NSString::from_str("drawsBackground");
+                            let _: () = msg_send![wk, setValue: &*no, forKey: &*key];
+                        }
+                    }
+                });
+            }
+
             // ── Themed launch background ──────────────────────────────
             // `tauri.conf.json` hardcodes a light window background, so a
             // dark-theme user would see a brief light flash in the gap
@@ -136,11 +166,13 @@ pub fn run() {
             // (The frontend re-asserts this on every theme change.)
             if theme.as_deref() == Some("dark") {
                 if let Some(win) = app.get_webview_window("main") {
-                    // Match the dark-shade's `--paper` in styles.css / DARK_PAPER.
+                    // Match the dark-shade's `--reader` in styles.css / DARK_BACKING
+                    // — the webview is non-opaque, so a resize exposes this colour
+                    // and it must blend with the reader pane, not the darker floor.
                     let (r, g, b) = match dark_shade.as_deref() {
-                        Some("dimmer") => (0x06, 0x05, 0x04),
-                        Some("black") => (0x00, 0x00, 0x00),
-                        _ => (0x0E, 0x0C, 0x0B),
+                        Some("dimmer") => (0x1C, 0x17, 0x15),
+                        Some("black") => (0x15, 0x10, 0x0F),
+                        _ => (0x25, 0x20, 0x1F),
                     };
                     let _ = win
                         .set_background_color(Some(tauri::window::Color(r, g, b, 0xFF)));

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,7 @@
         "height": 820,
         "minWidth": 920,
         "minHeight": 560,
-        "backgroundColor": "#F6F3EC",
+        "backgroundColor": "#FBF9F3",
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
         "trafficLightPosition": { "x": 13, "y": 19 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useQueryClient } from "@tanstack/react-query";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import * as api from "./api";
 import { useUi, READER_FONTS } from "./store";
@@ -82,14 +83,33 @@ export default function App() {
     root.style.setProperty("--accent", dark ? a.dAccent : a.accent);
     root.style.setProperty("--accent-soft", dark ? a.dSoft : a.soft);
     root.style.setProperty("--accent-ink", dark ? a.dInk : a.ink);
-    // Keep the native window/webview background on the themed paper colour, so
-    // a live window resize never flashes a mismatched colour in the strip the
-    // webview has not repainted yet. Mirrors --paper in styles.css, including
-    // the dark-shade override.
-    getCurrentWindow()
-      .setBackgroundColor(dark ? DARK_PAPER[darkShade] : "#F6F3EC")
-      .catch(() => {});
+    // Lock BOTH native layers to the themed paper colour. A live window resize
+    // briefly exposes the WKWebView's own backing before it repaints; that
+    // backing is opaque white unless we paint it, which is the strip that
+    // flashes white in dark mode. Setting the window colour alone is not enough
+    // — the webview sits on top of it — so we set both. Mirrors --paper in
+    // styles.css, including the dark-shade override.
+    const paper = dark ? DARK_PAPER[darkShade] : "#F6F3EC";
+    getCurrentWindow().setBackgroundColor(paper).catch(() => {});
+    getCurrentWebview().setBackgroundColor(paper).catch(() => {});
   }, [theme, darkShade, accent, density]);
+
+  // Re-assert the webview background on every resize. setBackgroundColor is
+  // persistent, but some macOS WebKit builds reset the webview's backing during
+  // a live resize — so we clamp it back each time the size changes, keeping the
+  // exposed strip on the paper colour instead of flashing white.
+  useEffect(() => {
+    const dark = theme === "dark";
+    const paper = dark ? DARK_PAPER[darkShade] : "#F6F3EC";
+    const win = getCurrentWindow();
+    const unlisten = win.onResized(() => {
+      getCurrentWindow().setBackgroundColor(paper).catch(() => {});
+      getCurrentWebview().setBackgroundColor(paper).catch(() => {});
+    });
+    return () => {
+      unlisten.then((f) => f()).catch(() => {});
+    };
+  }, [theme, darkShade]);
 
   // ── dismiss the boot splash once the app shell has mounted ──
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,33 +83,20 @@ export default function App() {
     root.style.setProperty("--accent", dark ? a.dAccent : a.accent);
     root.style.setProperty("--accent-soft", dark ? a.dSoft : a.soft);
     root.style.setProperty("--accent-ink", dark ? a.dInk : a.ink);
-    // Lock BOTH native layers to the themed paper colour. A live window resize
-    // briefly exposes the WKWebView's own backing before it repaints; that
-    // backing is opaque white unless we paint it, which is the strip that
-    // flashes white in dark mode. Setting the window colour alone is not enough
-    // — the webview sits on top of it — so we set both. Mirrors --paper in
-    // styles.css, including the dark-shade override.
+    // Keep BOTH native layers on the themed paper colour. On macOS the WKWebview
+    // is opaque and covers the whole content view, so a live resize exposes the
+    // *webview's own backing* (not the NSWindow's) in the strip it hasn't
+    // repainted yet. `getCurrentWindow().setBackgroundColor` only touches the
+    // NSWindow (plugin:window|set_background_color) — which the webview hides —
+    // so on its own it can't stop the resize flash; the webview backing has to
+    // be set too (plugin:webview|set_webview_background_color). The Rust launch
+    // path uses `WebviewWindow::set_background_color`, which already sets both;
+    // this is its runtime counterpart, run on every live theme/shade switch.
+    // Mirrors --paper in styles.css.
     const paper = dark ? DARK_PAPER[darkShade] : "#F6F3EC";
     getCurrentWindow().setBackgroundColor(paper).catch(() => {});
     getCurrentWebview().setBackgroundColor(paper).catch(() => {});
   }, [theme, darkShade, accent, density]);
-
-  // Re-assert the webview background on every resize. setBackgroundColor is
-  // persistent, but some macOS WebKit builds reset the webview's backing during
-  // a live resize — so we clamp it back each time the size changes, keeping the
-  // exposed strip on the paper colour instead of flashing white.
-  useEffect(() => {
-    const dark = theme === "dark";
-    const paper = dark ? DARK_PAPER[darkShade] : "#F6F3EC";
-    const win = getCurrentWindow();
-    const unlisten = win.onResized(() => {
-      getCurrentWindow().setBackgroundColor(paper).catch(() => {});
-      getCurrentWebview().setBackgroundColor(paper).catch(() => {});
-    });
-    return () => {
-      unlisten.then((f) => f()).catch(() => {});
-    };
-  }, [theme, darkShade]);
 
   // ── dismiss the boot splash once the app shell has mounted ──
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,12 +35,17 @@ const ACCENTS: Record<
   ink: { accent: "oklch(0.30 0.02 50)", soft: "oklch(0.92 0.005 50)", ink: "oklch(0.20 0.01 50)", dAccent: "oklch(0.86 0.005 50)", dSoft: "oklch(0.30 0.005 50)", dInk: "oklch(0.92 0.005 50)" },
 };
 
-// Native window background per dark-shade. Must match each shade's `--paper`
-// in styles.css so a window resize never flashes a mismatched strip.
-const DARK_PAPER: Record<DarkShade, string> = {
-  default: "#0E0C0B",
-  dimmer: "#060504",
-  black: "#000000",
+// Native window backing per dark-shade. The webview is made non-opaque in
+// lib.rs (to kill the white resize flash), so a resize exposes THIS colour in
+// the strip the webview hasn't repainted yet. Use each shade's `--reader`
+// (the widest pane, 1fr, and the right/bottom edge a resize is dragged from)
+// rather than the darker `--paper` floor — otherwise the exposed strip flashes
+// a shade darker than the reader content it sits next to. Mirrors `--reader`
+// in styles.css.
+const DARK_BACKING: Record<DarkShade, string> = {
+  default: "#25201F",
+  dimmer: "#1C1715",
+  black: "#15100F",
 };
 
 export default function App() {
@@ -83,19 +88,15 @@ export default function App() {
     root.style.setProperty("--accent", dark ? a.dAccent : a.accent);
     root.style.setProperty("--accent-soft", dark ? a.dSoft : a.soft);
     root.style.setProperty("--accent-ink", dark ? a.dInk : a.ink);
-    // Keep BOTH native layers on the themed paper colour. On macOS the WKWebview
-    // is opaque and covers the whole content view, so a live resize exposes the
-    // *webview's own backing* (not the NSWindow's) in the strip it hasn't
-    // repainted yet. `getCurrentWindow().setBackgroundColor` only touches the
-    // NSWindow (plugin:window|set_background_color) — which the webview hides —
-    // so on its own it can't stop the resize flash; the webview backing has to
-    // be set too (plugin:webview|set_webview_background_color). The Rust launch
-    // path uses `WebviewWindow::set_background_color`, which already sets both;
-    // this is its runtime counterpart, run on every live theme/shade switch.
-    // Mirrors --paper in styles.css.
-    const paper = dark ? DARK_PAPER[darkShade] : "#F6F3EC";
-    getCurrentWindow().setBackgroundColor(paper).catch(() => {});
-    getCurrentWebview().setBackgroundColor(paper).catch(() => {});
+    // Keep the native window backing on the themed reader colour. The webview is
+    // non-opaque on macOS (see lib.rs), so a live resize exposes the NSWindow
+    // background in the strip the webview hasn't repainted yet — use --reader so
+    // that strip blends with the reader pane it sits next to. (On Win/Linux the
+    // webview is opaque, so setBackgroundColor here mainly covers their own
+    // resize/overscroll; harmless on macOS where it's the NSWindow colour.)
+    const backing = dark ? DARK_BACKING[darkShade] : "#FBF9F3";
+    getCurrentWindow().setBackgroundColor(backing).catch(() => {});
+    getCurrentWebview().setBackgroundColor(backing).catch(() => {});
   }, [theme, darkShade, accent, density]);
 
   // ── dismiss the boot splash once the app shell has mounted ──

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,8 +37,8 @@ const ACCENTS: Record<
 // Native window background per dark-shade. Must match each shade's `--paper`
 // in styles.css so a window resize never flashes a mismatched strip.
 const DARK_PAPER: Record<DarkShade, string> = {
-  default: "#16140F",
-  dimmer: "#0E0C08",
+  default: "#0E0C0B",
+  dimmer: "#060504",
   black: "#000000",
 };
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1219,6 +1219,11 @@ button { font-family: inherit; }
 
 /* Selection */
 ::selection { background: var(--accent-soft); color: var(--accent-ink); }
+/* In dark, --accent-soft is a low-lightness terracotta; dragged across a whole
+   run of text it floods as a muddy khaki block (the same "accent must not fill"
+   problem the active row solves). So selection gets a neutral lift instead and
+   keeps the text its own ink colour. */
+[data-theme="dark"] ::selection { background: rgba(246, 240, 238, 0.16); color: var(--ink); }
 
 /* ====== Settings ====== */
 .settings-backdrop {

--- a/src/styles.css
+++ b/src/styles.css
@@ -62,27 +62,40 @@
 
 [data-theme="dark"] {
   color-scheme: dark;
-  --paper: #16140F;
-  --panel: #1B1812;
-  --panel-2: #221E18;
-  --reader: #1B1812;
+  /* "Editorial Quiet", dark. The chrome (window, sidebar, list) stays cool and
+     near-neutral; warmth is reserved for the reading surface so the page reads
+     as a sheet of lamp-lit paper and the rest recedes. Crucially the surfaces
+     now STEP in lightness — sidebar darkest, list lighter, reader lightest —
+     instead of sitting at one flat tone, so the three panes read as depth, not
+     a single grey field. The reader also carries roughly double the chroma so
+     it alone feels like paper, not metal.
+     Hue note: every surface sits at oklch hue ~40-42 (red-leaning terracotta),
+     NOT 55-66. On a near-black field a warm hue past ~50 reads as dirty yellow/
+     khaki ("淡淡的黄") — keeping the tint red-leaning and very low-chroma gives
+     warmth without ever going yellow. Do not raise these hues back toward 60. */
+  --paper: oklch(0.155 0.004 40);   /* #0e0c0b — window floor, deepest */
+  --panel: oklch(0.190 0.005 40);   /* #161312 — sidebar, recedes */
+  --panel-2: oklch(0.230 0.005 40); /* #1f1c1b — list rows + floating menus */
+  --reader: oklch(0.250 0.008 42);  /* #25201f — reading surface, warm & lit */
 
-  --ink: #ECE7DC;
-  --ink-2: #C7C1B3;
-  --muted: #8B8479;
-  --muted-2: #5F594F;
-  --hair: rgba(255, 248, 230, 0.08);
-  --hair-strong: rgba(255, 248, 230, 0.14);
-  --hover: rgba(255, 248, 230, 0.05);
-  --selected: rgba(255, 248, 230, 0.07);
+  --ink: oklch(0.930 0.006 50);     /* #ebe7e4 — soft warm white, never #fff */
+  --ink-2: oklch(0.800 0.006 48);
+  --muted: oklch(0.605 0.006 45);
+  --muted-2: oklch(0.455 0.006 44);
+  /* Hairlines do real work here — they're what makes the stepped panes read as
+     crisp divisions rather than a soft blur, so they're a touch stronger. */
+  --hair: rgba(246, 240, 238, 0.09);
+  --hair-strong: rgba(246, 240, 238, 0.15);
+  --hover: rgba(246, 240, 238, 0.05);
+  --selected: rgba(246, 240, 238, 0.07);
 
-  --accent: oklch(0.74 0.13 45);
-  /* Highlight wash for selected rows, ::selection and active sidebar items.
-     The old oklch(0.32 0.06 40) (#4C271A) sat low and warm enough to read as a
-     muddy dried-blood brown; lifting it brighter and slightly more golden keeps
-     the terracotta identity while looking clean against the dark surfaces. */
-  --accent-soft: oklch(0.42 0.06 48);
-  --accent-ink: oklch(0.80 0.10 45);
+  /* One accent, used rarely. Terracotta clay, calm — it tints small marks (the
+     active dot, a link, a tag), never floods a whole surface. */
+  --accent: oklch(0.70 0.115 42);   /* #da8564 */
+  /* The selected/active wash: a restrained warm tone that lifts off the stepped
+     surfaces enough to register, without the loud orange block of before. */
+  --accent-soft: oklch(0.34 0.045 44); /* #4c3025 */
+  --accent-ink: oklch(0.78 0.10 44);
 
   --danger: oklch(0.68 0.16 28);
   --danger-soft: oklch(0.30 0.07 28);
@@ -92,9 +105,10 @@
   --warn: oklch(0.70 0.16 40);
   --toast-alert: oklch(0.50 0.17 28);
 
-  --shadow-raise: 0 1px 2px oklch(0 0 0 / 0.45);
-  --shadow-pop: 0 14px 38px oklch(0 0 0 / 0.55);
-  --shadow-modal: 0 26px 64px oklch(0 0 0 / 0.62);
+  /* Quiet, faintly warm elevation — depth without joining the colour story. */
+  --shadow-raise: 0 1px 2px oklch(0.06 0.006 40 / 0.5);
+  --shadow-pop: 0 14px 38px oklch(0.05 0.006 40 / 0.6);
+  --shadow-modal: 0 26px 64px oklch(0.04 0.005 40 / 0.68);
   --shadow-ring: 0 0 0 1px oklch(0 0 0 / 0.3);
 }
 
@@ -102,17 +116,43 @@
    hue; ink, accents and borders stay as the base dark theme defines them.
    "default" needs no block (it uses the values above). */
 [data-theme="dark"][data-dark-shade="dimmer"] {
-  --paper: #0E0C08;
-  --panel: #131009;
-  --panel-2: #19150D;
-  --reader: #131009;
+  --paper: oklch(0.115 0.004 40);   /* #060504 */
+  --panel: oklch(0.150 0.005 40);   /* #0d0a0a */
+  --panel-2: oklch(0.190 0.005 40); /* #161312 */
+  --reader: oklch(0.210 0.008 42);  /* #1c1715 — reader stays warm & lifted */
 }
 [data-theme="dark"][data-dark-shade="black"] {
+  /* True-black window for OLED — but the panes keep stepping up and the reader
+     stays a warm lit sheet, so it never collapses into flat grey-on-black. */
   --paper: #000000;
-  --panel: #0A0908;
-  --panel-2: #121009;
-  --reader: #0A0908;
+  --panel: oklch(0.105 0.004 40);   /* #050403 */
+  --panel-2: oklch(0.150 0.005 40); /* #0d0a0a */
+  --reader: oklch(0.180 0.008 42);  /* #15100f */
 }
+
+/* ── Dark theme: accent as a mark, not a fill ──────────────────────────────
+   Painting whole active rows in --accent-soft read as a muddy "rust" block at
+   these low lightnesses ("锈迹斑斑"). In dark, the active row instead gets a
+   neutral lift, the list item a thin terracotta bar, and per-row feed names go
+   quiet — so the warm accent only ever shows up as a small mark. Small uses of
+   --accent-soft (text selection, focus rings, tag hover) are left alone; at that
+   size they don't muddy. Light theme keeps its pale terracotta washes. */
+[data-theme="dark"] .sb-item.active {
+  background: rgba(246, 240, 238, 0.10);
+  color: var(--ink);
+}
+[data-theme="dark"] .sb-item.active .sb-count { color: var(--muted); }
+
+[data-theme="dark"] .art.active { background: rgba(246, 240, 238, 0.09); }
+[data-theme="dark"] .art.active::before {
+  content: "";
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 3px;
+  background: var(--accent);
+}
+
+[data-theme="dark"] .art-feed { color: var(--muted); }
 
 [data-density="compact"] { --row-py: 10px; --list-px: 14px; }
 [data-density="cozy"]    { --row-py: 14px; --list-px: 18px; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -164,9 +164,12 @@
 
 * { box-sizing: border-box; }
 html, body, #root { height: 100%; margin: 0; }
-/* The window is transparent, so a window resize briefly exposes the
-   document background before `.window` repaints. Keep it on the themed
-   paper colour — a hardcoded dark value flashed black in the light theme. */
+/* Keep the document background on the themed paper colour so any strip a
+   resize exposes before `.window` repaints matches. NOTE: this alone does NOT
+   fix the macOS resize flash — the WKWebview is opaque and hides this layer;
+   the real fix is setting the webview's native backing per theme (see the
+   setBackgroundColor calls in App.tsx). A hardcoded dark value here flashed
+   black in the light theme, so it stays var(--paper). */
 html { background: var(--paper); }
 body {
   background: var(--paper);

--- a/src/styles.css
+++ b/src/styles.css
@@ -73,7 +73,11 @@
      NOT 55-66. On a near-black field a warm hue past ~50 reads as dirty yellow/
      khaki ("淡淡的黄") — keeping the tint red-leaning and very low-chroma gives
      warmth without ever going yellow. Do not raise these hues back toward 60. */
-  --paper: oklch(0.155 0.004 40);   /* #0e0c0b — window floor, deepest */
+  /* hex, not oklch: this var paints the root `html` background, and a
+     root-propagated oklch viewport background flashes white in the strip
+     WebKit exposes during a live window resize. The other surfaces below stay
+     oklch — they sit on child elements, not the viewport, so they're unaffected. */
+  --paper: #0e0c0b;                 /* window floor, deepest */
   --panel: oklch(0.190 0.005 40);   /* #161312 — sidebar, recedes */
   --panel-2: oklch(0.230 0.005 40); /* #1f1c1b — list rows + floating menus */
   --reader: oklch(0.250 0.008 42);  /* #25201f — reading surface, warm & lit */
@@ -116,7 +120,7 @@
    hue; ink, accents and borders stay as the base dark theme defines them.
    "default" needs no block (it uses the values above). */
 [data-theme="dark"][data-dark-shade="dimmer"] {
-  --paper: oklch(0.115 0.004 40);   /* #060504 */
+  --paper: #060504;                 /* hex — root background, see note above */
   --panel: oklch(0.150 0.005 40);   /* #0d0a0a */
   --panel-2: oklch(0.190 0.005 40); /* #161312 */
   --reader: oklch(0.210 0.008 42);  /* #1c1715 — reader stays warm & lifted */

--- a/src/styles.css
+++ b/src/styles.css
@@ -77,7 +77,11 @@
   --selected: rgba(255, 248, 230, 0.07);
 
   --accent: oklch(0.74 0.13 45);
-  --accent-soft: oklch(0.32 0.06 40);
+  /* Highlight wash for selected rows, ::selection and active sidebar items.
+     The old oklch(0.32 0.06 40) (#4C271A) sat low and warm enough to read as a
+     muddy dried-blood brown; lifting it brighter and slightly more golden keeps
+     the terracotta identity while looking clean against the dark surfaces. */
+  --accent-soft: oklch(0.42 0.06 48);
   --accent-ink: oklch(0.80 0.10 45);
 
   --danger: oklch(0.68 0.16 28);

--- a/src/styles.css
+++ b/src/styles.css
@@ -905,6 +905,11 @@ button { font-family: inherit; }
   justify-content: center;
   color: var(--muted-2);
 }
+/* On the dark reader surface --panel is *darker* than --reader, so the glyph
+   reads as a black tile punched into the page. Lift it with a faint neutral
+   wash instead — the same way active rows lift in dark — so it sits as a quiet
+   mark on the sheet, not a hole in it. */
+[data-theme="dark"] .empty .glyph { background: rgba(246, 240, 238, 0.05); }
 .empty-retry {
   background: var(--panel);
   border: 1px solid var(--hair);


### PR DESCRIPTION
## What

Three related dark-theme fixes, all addressing the same root issue: the terracotta accent was being used to *fill* surfaces, where at low lightness it reads as a muddy khaki/rust block.

- **Redesign dark theme** — stepped neutral surfaces (sidebar darkest → list → reader lightest, so the panes read as depth not one flat grey), and the accent demoted to a small mark (active dot, link, thin bar) instead of a flooded row.
- **Brighten muddy highlight wash** — the dark-mode highlight wash was too dim/muddy.
- **Neutral text selection** — dragging across body text painted `--accent-soft` as a khaki block. Dark-mode `::selection` now uses a neutral lift and keeps the text its own ink colour. Light mode unchanged.

## Test plan

- [ ] Toggle dark mode, check sidebar/list/reader read as stepped surfaces
- [ ] Select a run of body text in the reader — selection is a neutral grey lift, text stays readable
- [ ] Active sidebar/list rows show the accent as a thin mark, not a filled block

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined the dark “Editorial Quiet” palette, updating surface, typography, border, accent, and shadow/elevation tones
  * Tweaked dark active-state and accent marks for a more neutral, subtle appearance
  * Improved dark selection contrast and adjusted the dark empty-state glyph to read as a “punched” mark
* **Bug Fixes**
  * Improved dark-mode background handling on macOS to prevent white flashing during live resize
  * Updated native/webview dark-shade background colors for “default” and “dimmer” launches
<!-- end of auto-generated comment: release notes by coderabbit.ai -->