### PR TITLE
feat(reader): in-app original-page view (#49)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,7 +13,11 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["tray-icon", "image-png"] }
+# `unstable` unlocks the child-webview API (Window::add_child) used by the
+# in-app original-page view (issue #49) — sites that refuse iframes
+# (X-Frame-Options) still render in a native child webview. API may change
+# across Tauri minors; pinned via Cargo.lock.
+tauri = { version = "2", features = ["tray-icon", "image-png", "unstable"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-autostart = "2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod ingestion;
 mod models;
 mod notify;
 mod opml;
+mod page_view;
 mod sanitize;
 mod state;
 mod sync;
@@ -254,6 +255,9 @@ pub fn run() {
             commands::update_highlight_note,
             commands::set_highlight_color,
             commands::delete_highlight,
+            page_view::open_page_view,
+            page_view::set_page_view_bounds,
+            page_view::close_page_view,
         ])
         .run(tauri::generate_context!())
         .expect("error while running Papr");

--- a/src-tauri/src/page_view.rs
+++ b/src-tauri/src/page_view.rs
@@ -1,0 +1,91 @@
+//! In-app original-page view (issue #49).
+//!
+//! A child webview overlaid on the main window's reading area, so feeds that
+//! only ship a summary — or sites that refuse to be framed via
+//! `X-Frame-Options` (V2EX, most news/community sites) — still render inside
+//! Papr. An `<iframe>` cannot do this: the remote server rejects the frame and
+//! the browser gives no reliable failure signal across origins. A native child
+//! webview is a real WebView, so framing headers do not apply.
+//!
+//! The child webview is NOT in the DOM — it floats above the main webview — so
+//! the frontend measures the reading area and feeds us logical (CSS-px) bounds,
+//! and re-sends them whenever the window resizes.
+//!
+//! Security: the `page-view` label appears in no capability (see
+//! `capabilities/default.json`, scoped to `["main"]`), so even though Tauri
+//! injects its IPC bridge, the ACL denies every command — remote pages cannot
+//! reach the backend.
+//!
+//! Built on Tauri's `unstable` child-webview API; see `Cargo.toml`.
+
+use tauri::{
+    webview::WebviewBuilder, AppHandle, LogicalPosition, LogicalSize, Manager, WebviewUrl,
+};
+
+/// Label of the single, reused original-page child webview.
+const LABEL: &str = "page-view";
+
+fn parse_url(url: &str) -> Result<url::Url, String> {
+    url.parse().map_err(|_| format!("invalid url: {url}"))
+}
+
+/// Show the original page at `url` over the given reading-area rectangle.
+/// Reuses the existing child webview when already open (just navigate + move),
+/// so switching articles doesn't flash a teardown/rebuild.
+#[tauri::command]
+pub async fn open_page_view(
+    app: AppHandle,
+    url: String,
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+) -> Result<(), String> {
+    let parsed = parse_url(&url)?;
+    let position = LogicalPosition::new(x, y);
+    let size = LogicalSize::new(width, height);
+
+    if let Some(view) = app.get_webview(LABEL) {
+        view.navigate(parsed).map_err(|e| e.to_string())?;
+        view.set_position(position).map_err(|e| e.to_string())?;
+        view.set_size(size).map_err(|e| e.to_string())?;
+        return Ok(());
+    }
+
+    // `get_window` / `add_child` are part of the `unstable` feature. The main
+    // WebviewWindow's underlying Window shares its "main" label.
+    let window = app.get_window("main").ok_or("main window not found")?;
+    let builder = WebviewBuilder::new(LABEL, WebviewUrl::External(parsed));
+    window
+        .add_child(builder, position, size)
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// Reposition/resize the open page view (window resized, sidebar toggled, …).
+/// No-op when the view isn't open.
+#[tauri::command]
+pub async fn set_page_view_bounds(
+    app: AppHandle,
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+) -> Result<(), String> {
+    if let Some(view) = app.get_webview(LABEL) {
+        view.set_position(LogicalPosition::new(x, y))
+            .map_err(|e| e.to_string())?;
+        view.set_size(LogicalSize::new(width, height))
+            .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+/// Tear down the page view (left web mode, switched away, reader unmounted).
+#[tauri::command]
+pub async fn close_page_view(app: AppHandle) -> Result<(), String> {
+    if let Some(view) = app.get_webview(LABEL) {
+        view.close().map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -289,3 +289,19 @@ export const listNewsletterSources = () =>
   invoke<NewsletterSource[]>("list_newsletter_sources");
 export const removeNewsletterSource = (feedId: number) =>
   invoke<void>("remove_newsletter_source", { feedId });
+
+// ── in-app original-page view (issue #49) ──
+// A native child webview overlaid on the reading area. Bounds are logical
+// (CSS) pixels relative to the window content top-left — i.e. what
+// getBoundingClientRect returns inside the main webview.
+export interface PageViewBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+export const openPageView = (url: string, b: PageViewBounds) =>
+  invoke<void>("open_page_view", { url, ...b });
+export const setPageViewBounds = (b: PageViewBounds) =>
+  invoke<void>("set_page_view_bounds", { ...b });
+export const closePageView = () => invoke<void>("close_page_view");

--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -183,6 +183,10 @@ export default function Reader({ onToast }: Props) {
   // opt-in via the toolbar button; on shows the extracted full text.
   const [showExtracted, setShowExtracted] = useState(autoExtract);
   const [showTranslation, setShowTranslation] = useState(false);
+  // Reading vs. the article's original web page, shown in an in-app iframe.
+  // Sites that set X-Frame-Options / CSP frame-ancestors refuse to load this
+  // way — the in-frame hint points those back to "open in browser".
+  const [viewMode, setViewMode] = useState<"reader" | "web">("reader");
   const [tagPick, setTagPick] = useState<{ x: number; y: number } | null>(null);
   const [ctxMenu, setCtxMenu] = useState<{
     x: number;
@@ -209,6 +213,8 @@ export default function Reader({ onToast }: Props) {
   }, [heroBlob]);
   const scrollRef = useRef<HTMLDivElement>(null);
   const bodyRef = useRef<HTMLDivElement>(null);
+  // Host element the native original-page child webview is positioned over.
+  const pageHostRef = useRef<HTMLDivElement>(null);
   // Article id we already auto-marked read via scroll, so a flurry of scroll
   // events near the foot doesn't fire `setRead` repeatedly before the
   // optimistic cache patch lands.
@@ -233,6 +239,7 @@ export default function Reader({ onToast }: Props) {
   useEffect(() => {
     setShowExtracted(useUi.getState().prefs.autoExtract);
     setShowTranslation(false);
+    setViewMode("reader");
     setScrolled(false);
     setTagPick(null);
     setHeroBroken(false);
@@ -240,6 +247,41 @@ export default function Reader({ onToast }: Props) {
     scrollMarkedRef.current = null;
     if (scrollRef.current) scrollRef.current.scrollTop = 0;
   }, [id]);
+
+  // Drive the native original-page child webview (page_view.rs) while in web
+  // mode. It floats above the DOM, so we measure the host rect and keep the
+  // webview aligned to it across window/sidebar resizes. (Switching articles
+  // resets viewMode to "reader" above, so a.url is stable within a session.)
+  const articleUrl = a?.url ?? null;
+  useEffect(() => {
+    const host = pageHostRef.current;
+    if (viewMode !== "web" || !articleUrl || !host) return;
+
+    const bounds = () => {
+      const r = host.getBoundingClientRect();
+      return { x: r.left, y: r.top, width: r.width, height: r.height };
+    };
+    let open = false;
+    api.openPageView(articleUrl, bounds()).then(
+      () => {
+        open = true;
+      },
+      () => {},
+    );
+
+    const sync = () => {
+      if (open) api.setPageViewBounds(bounds()).catch(() => {});
+    };
+    const ro = new ResizeObserver(sync);
+    ro.observe(host);
+    window.addEventListener("resize", sync);
+
+    return () => {
+      ro.disconnect();
+      window.removeEventListener("resize", sync);
+      api.closePageView().catch(() => {});
+    };
+  }, [viewMode, articleUrl]);
 
   // Recover article-body images the webview fails to load, then hide the
   // stragglers. The webview sends no Referer (see sanitize.rs) — right for
@@ -734,6 +776,17 @@ export default function Reader({ onToast }: Props) {
         <div className="tb-btn spacer" />
         {a.url && (
           <button
+            className={`tb-btn ${viewMode === "web" ? "on" : ""}`}
+            title={t("reader.tbWebView")}
+            aria-label={t("reader.tbWebView")}
+            aria-pressed={viewMode === "web"}
+            onClick={() => setViewMode((v) => (v === "web" ? "reader" : "web"))}
+          >
+            <Icon name="eye" size={16} />
+          </button>
+        )}
+        {a.url && (
+          <button
             className="tb-btn"
             title={t("reader.tbOpenInBrowser")}
             aria-label={t("reader.tbOpenInBrowser")}
@@ -744,6 +797,23 @@ export default function Reader({ onToast }: Props) {
         )}
       </div>
 
+      {viewMode === "web" && a.url ? (
+        <div className="reader-webview">
+          <div className="reader-webview-bar">
+            <span className="reader-webview-url">{a.url}</span>
+            <button
+              className="reader-webview-open"
+              onClick={() => openUrl(a.url!).catch(() => {})}
+            >
+              {t("reader.tbOpenInBrowser")}
+            </button>
+          </div>
+          {/* The native child webview (page_view.rs) floats over this host —
+              it's not in the DOM, so this div only reserves the space. The
+              effect below measures it and positions the webview to match. */}
+          <div className="reader-webview-host" ref={pageHostRef} />
+        </div>
+      ) : (
       <div
         className="reader-scroll"
         ref={scrollRef}
@@ -965,6 +1035,7 @@ export default function Reader({ onToast }: Props) {
           />
         </article>
       </div>
+      )}
 
       <AIDrawer
         // Keyed by article id so switching articles remounts the drawer:

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -183,6 +183,7 @@
     "tbTags": "Tags",
     "tbFocusMode": "Focus mode (F)",
     "tbOpenInBrowser": "Open in browser (⌘O)",
+    "tbWebView": "Open original page here",
     "episodePlay": "Play episode",
     "episodePlaying": "Now playing",
     "readMinutes": "{{count}} min read",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -183,6 +183,7 @@
     "tbTags": "タグ",
     "tbFocusMode": "集中モード (F)",
     "tbOpenInBrowser": "ブラウザで開く (⌘O)",
+    "tbWebView": "元のページをここで開く",
     "episodePlay": "エピソードを再生",
     "episodePlaying": "再生中",
     "readMinutes": "{{count}} 分で読了",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -183,6 +183,7 @@
     "tbTags": "标签",
     "tbFocusMode": "焦点阅读 (F)",
     "tbOpenInBrowser": "在浏览器中打开 (⌘O)",
+    "tbWebView": "在此打开原网页",
     "episodePlay": "播放音频",
     "episodePlaying": "正在播放",
     "readMinutes": "{{count}} 分钟阅读",

--- a/src/styles.css
+++ b/src/styles.css
@@ -596,6 +596,52 @@ button { font-family: inherit; }
   overflow-y: auto;
 }
 
+/* In-app original-page view (issue #49): a thin address bar over a host div.
+   A native child webview (page_view.rs) is positioned over `.reader-webview-host`
+   — it is NOT in the DOM, so the host only reserves the space and shows a
+   neutral backdrop until the webview paints. */
+.reader-webview {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.reader-webview-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 18px;
+  font-size: 12px;
+  color: var(--muted);
+  background: var(--paper);
+  border-bottom: 1px solid var(--line);
+  flex-shrink: 0;
+}
+.reader-webview-url {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.reader-webview-open {
+  flex-shrink: 0;
+  color: var(--accent);
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 12px;
+  padding: 0;
+}
+.reader-webview-open:hover {
+  text-decoration: underline;
+}
+.reader-webview-host {
+  flex: 1;
+  min-height: 0;
+  background: #fff;
+}
+
 .article {
   max-width: 680px;
   margin: 0 auto;


### PR DESCRIPTION
Closes #49.

## What
A toolbar toggle (eye icon, next to *Open in browser*) that opens the current article's **original web page inside the reading area**, so you can flip between the reader / full-text view and the live page without leaving Papr. Useful for summary-only feeds, sites that depend on their own layout, and pages whose full text Papr can't extract (e.g. BestBlogs).

## Why a native child webview, not an `<iframe>`
An early `<iframe>` cut failed on exactly the sites that need this most: **V2EX and most news/community sites set `X-Frame-Options` / CSP `frame-ancestors` and refuse to be framed**, and cross-origin framing failures give no reliable JS signal to fall back on.

This uses Tauri's **native child webview** (`Window::add_child`, behind the `unstable` feature) instead. A native WebView is not subject to those framing headers, so V2EX et al. render normally.

## How it works
- `src-tauri/src/page_view.rs` — three commands: `open_page_view` / `set_page_view_bounds` / `close_page_view`. The child webview (label `page-view`) is reused across opens (navigate + reposition).
- The child webview floats **above** the DOM (it isn't an element), so `Reader.tsx` measures a host `<div>` and keeps the webview aligned to it across window / sidebar resizes via `ResizeObserver` + window `resize`.
- Switching articles resets back to reader mode, so a stale page is never shown for the wrong article.

## Security
The `page-view` webview is in **no capability** (`capabilities/default.json` is scoped to `["main"]`), so even though Tauri injects its IPC bridge, the ACL denies every command — remote pages cannot reach the backend. *Open in browser* remains as a fallback.

## Notes / trade-offs
- Relies on Tauri's `unstable` child-webview API; pinned via `Cargo.lock`.
- i18n added for `en` / `zh` / `ja`.

## Verification
- `tsc --noEmit` clean, `vitest` 63/63, `vite build` OK, `cargo check` clean.
- Manually verified in `tauri dev`: V2EX (which `X-Frame-Options`-blocks iframes) opens in-app; alignment holds on window resize.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a web view mode to display original pages within the app. Users can toggle between the reader view and the original webpage with automatic positioning and resizing.
  * Localization support added for the new web view toggle in English, Japanese, and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->