### PR TITLE
fix(reader): theme page-view backdrop + close orphaned child webview

### DIFF
--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -242,21 +242,27 @@ export default function Reader({ onToast }: Props) {
       return { x: r.left, y: r.top, width: r.width, height: r.height };
     };
     let open = false;
+    let cancelled = false;
     api.openPageView(articleUrl, bounds()).then(
       () => {
         open = true;
+        // If teardown ran while this open was still in flight, the cleanup's
+        // closePageView fired against a not-yet-created webview (a no-op) and
+        // would leave this one orphaned above the DOM — close it now.
+        if (cancelled) api.closePageView().catch(() => {});
       },
       () => {},
     );
 
     const sync = () => {
-      if (open) api.setPageViewBounds(bounds()).catch(() => {});
+      if (open && !cancelled) api.setPageViewBounds(bounds()).catch(() => {});
     };
     const ro = new ResizeObserver(sync);
     ro.observe(host);
     window.addEventListener("resize", sync);
 
     return () => {
+      cancelled = true;
       ro.disconnect();
       window.removeEventListener("resize", sync);
       api.closePageView().catch(() => {});

--- a/src/styles.css
+++ b/src/styles.css
@@ -690,7 +690,10 @@ button { font-family: inherit; }
 .reader-webview-host {
   flex: 1;
   min-height: 0;
-  background: #fff;
+  /* Themed floor, not hard `#fff`: the native webview paints over this, but
+     until it does, a white tile flashes in the dark theme (the very flash the
+     recent window fixes chased). `--paper` is dark in dark mode, cream in light. */
+  background: var(--paper);
 }
 
 .article {


### PR DESCRIPTION
Two small follow-ups to the in-app original-page view (#50).

## 1. Dark-theme flash on the page-view backdrop
`.reader-webview-host` was hard-coded `background: #fff`. The native child webview paints over it, but until it does a **white tile flashes in the dark theme** — the same class of resize-flash the recent window fixes chased. Switched to `var(--paper)` (dark in dark mode, cream in light), matching the address bar just above it.

## 2. Orphaned child webview on a teardown/open race
`open_page_view` is async on the Rust side. If the effect tore down (article switch, toggle off, unmount) **while an open was still in flight**, the cleanup's `closePageView` ran against a not-yet-created webview (a no-op), and the webview that resolved a moment later was **orphaned above the DOM forever**. Now a `cancelled` flag is set on teardown and the late-resolving open closes itself.

## Verification
- `tsc --noEmit` clean
- `vitest` 70/70
- CSS + frontend only; no Rust touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined webview cleanup process to properly handle component unmounting scenarios
  * Eliminated white flash in dark mode by updating the page viewer to use theme-aware styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->