### PR TITLE
Bump version to 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "papr",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "papr"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "papr"
-version = "0.8.0"
+version = "0.9.0"
 description = "Papr — a modern RSS reader"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Papr",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "identifier": "com.thomas.papr",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release bump 0.8.0 → 0.9.0 (minor: new features since v0.8.0).

Bumps `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.lock`.

Shipping since v0.8.0:
- feat: in-app original-page view via native child webview (#50)
- feat: inline HTML5 `<video>` in feed content (#45)
- fix: theme page-view backdrop + close orphaned child webview (#51)
- fix: keep recovered images alive across scroll (#44)
- fix: dark-mode accent fixes (#48)
- fix: normalise empty URLs / blank folder names in OPML build (#47)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.9.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->