### PR TITLE
fix(tray): live-update menu-bar count on macOS

### DIFF
--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -249,15 +249,25 @@ pub async fn refresh(app: &AppHandle) {
             db::latest_fetch(&conn).ok().flatten(),
         )
     };
-    let Some(tray) = app.tray_by_id(TRAY_ID) else {
-        return;
-    };
-    if let Ok(menu) = build_menu(app, &lang, unread, last.as_deref()) {
-        let _ = tray.set_menu(Some(menu));
-    }
-    let _ = tray.set_title(if unread > 0 {
-        Some(unread.to_string())
-    } else {
-        None
+    // Tray mutations touch AppKit, which on macOS must happen on the main
+    // thread. Callers reach here from the async runtime (commands and the
+    // background scheduler), where `set_menu`/`set_title` would silently
+    // no-op — so hop onto the main thread before touching the tray.
+    let app = app.clone();
+    let _ = app.clone().run_on_main_thread(move || {
+        let Some(tray) = app.tray_by_id(TRAY_ID) else {
+            return;
+        };
+        if let Ok(menu) = build_menu(&app, &lang, unread, last.as_deref()) {
+            let _ = tray.set_menu(Some(menu));
+        }
+        // Pass an empty string rather than `None` to clear the count: on
+        // macOS `set_title(None)` leaves the previous title in place, so a
+        // drop to zero would otherwise keep showing the stale number.
+        let _ = tray.set_title(Some(if unread > 0 {
+            unread.to_string()
+        } else {
+            String::new()
+        }));
     });
 }


### PR DESCRIPTION
## 问题

托盘菜单栏的未读数从启动后就不再更新——点"全部标为已读"、刷新拉到新文章都一样，数字一直停在启动那一刻的值。

## 根因

托盘的 \`set_menu\` / \`set_title\` 是 macOS AppKit 调用，**必须在主线程**执行。但 \`tray::refresh()\` 的所有调用方都跑在 tokio 异步运行时上：

- \`mark_all_read\` / \`mark_read\` 命令（\`refresh_unread_surfaces\`）
- 托盘菜单事件里的 \`async_runtime::spawn\`
- 后台刷新调度器（\`scheduler.rs\`）

只有启动时的 \`tray::build()\` 在 \`setup()\`（主线程）里执行，所以启动那一刻计数正确，之后每次 \`refresh()\` 都在非主线程静默失效。

此外，即便菜单文案更新了，菜单栏图标旁的数字也清不掉——因为在 macOS 上 \`set_title(None)\` 会保留旧标题。

## 修改

\`src-tauri/src/tray.rs\` 的 \`refresh()\`：

1. 异步线程读完数据库后，用 \`app.run_on_main_thread(...)\` 把 \`tray_by_id\` + 菜单重建 + \`set_menu\` + \`set_title\` 整体派发到主线程。
2. 清空计数时改用空字符串 \`Some("")\` 而非 \`None\`，否则归零时会残留旧数字。

## 验证

本地 \`npm run tauri dev\` 实测：标记已读 / 全部标为已读 / 刷新拉新文章，菜单栏数字均实时变化，归零时正确消失；菜单文案（未读数、上次刷新）也同步更新。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed tray menu and title updates on macOS to properly clear unread count indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->