### PR TITLE
fix(reader): close native page-view webview when opening modals (#54)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,6 +77,15 @@ export default function App() {
   const [explore, setExplore] = useState(false);
   const [newFolder, setNewFolder] = useState(false);
 
+  // Mirror "any covering modal is open" into the store. The reader's
+  // original-page view is a native child webview that floats above the whole
+  // DOM, so it would occlude a dialog opened over the reader (issue #54). The
+  // reader watches this flag and tears the view down while a modal is up.
+  const setModalOpen = useUi((s) => s.setModalOpen);
+  useEffect(() => {
+    setModalOpen(cpOpen || settings.open || addFeed || explore || newFolder);
+  }, [cpOpen, settings.open, addFeed, explore, newFolder, setModalOpen]);
+
   // ── apply appearance to the document root ──
   useEffect(() => {
     const root = document.documentElement;

--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -233,9 +233,16 @@ export default function Reader({ onToast }: Props) {
   // webview aligned to it across window/sidebar resizes. (Switching articles
   // resets viewMode to "reader" above, so a.url is stable within a session.)
   const articleUrl = a?.url ?? null;
+  // Anything that floats over the reading area suspends the page view: the
+  // child webview floats above the whole DOM, so it would otherwise occlude a
+  // covering modal (subscribe / settings / explore — issue #54) or the AI
+  // drawer that slides over the reader's right edge. When the overlay closes
+  // this effect re-runs and re-opens the view at the current bounds.
+  const modalOpen = useUi((s) => s.modalOpen);
+  const overlayOpen = modalOpen || aiOpen;
   useEffect(() => {
     const host = pageHostRef.current;
-    if (viewMode !== "web" || !articleUrl || !host) return;
+    if (viewMode !== "web" || !articleUrl || !host || overlayOpen) return;
 
     const bounds = () => {
       const r = host.getBoundingClientRect();
@@ -267,7 +274,7 @@ export default function Reader({ onToast }: Props) {
       window.removeEventListener("resize", sync);
       api.closePageView().catch(() => {});
     };
-  }, [viewMode, articleUrl]);
+  }, [viewMode, articleUrl, overlayOpen]);
 
   // Recover article-body images the webview fails to load, then hide the
   // stragglers. The webview sends no Referer (see sanitize.rs) — right for

--- a/src/store.ts
+++ b/src/store.ts
@@ -114,6 +114,11 @@ interface UiState {
   // transient view modes
   focusMode: boolean;
   aiOpen: boolean;
+  /** A covering modal (subscribe / settings / explore …) is open. The reader's
+   *  original-page view is a native child webview that floats above the whole
+   *  DOM — including modals — so it must be torn down while one is up, or it
+   *  occludes the dialog (issue #54). The reader effect watches this flag. */
+  modalOpen: boolean;
 
   select: (query: ArticleQuery, label: string) => void;
   openArticle: (id: number | null) => void;
@@ -132,6 +137,7 @@ interface UiState {
 
   setFocusMode: (v: boolean) => void;
   setAiOpen: (v: boolean) => void;
+  setModalOpen: (v: boolean) => void;
 }
 
 const PREF_KEYS: (keyof Prefs)[] = [
@@ -222,6 +228,7 @@ export const useUi = create<UiState>((set) => ({
 
   focusMode: false,
   aiOpen: false,
+  modalOpen: false,
 
   select: (query, label) => {
     // Remember the selection so the "open on startup: last view" preference
@@ -271,6 +278,7 @@ export const useUi = create<UiState>((set) => ({
 
   setFocusMode: (focusMode) => set({ focusMode }),
   setAiOpen: (aiOpen) => set({ aiOpen }),
+  setModalOpen: (modalOpen) => set({ modalOpen }),
 }));
 
 // Seed the backend's theme copy on startup so an existing install — whose


### PR DESCRIPTION
Closes #54

## 根因
"查看原文" 使用原生 child webview（`src-tauri/src/page_view.rs`），不在 DOM 中，永远悬浮在所有 web 内容之上。订阅弹窗等是 DOM 模态框，打开时既不改变 `viewMode` 也不卸载 Reader，因此原生 webview 始终遮住弹窗。

## 修复
复用 #51 的 `closePageView` 机制：store 新增 `modalOpen` 标志，任意覆盖型浮层（订阅/设置/Explore/命令面板/AI 抽屉）打开时挂起原生 webview，关闭后重新打开。

## 验证
`pnpm build` 通过；`pnpm test` 70 个测试全过。

改动文件：`src/store.ts`、`src/App.tsx`、`src/components/Reader.tsx`（+26/-2）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved coordination between modal dialogs and the reader component to prevent unwanted interactions when overlays are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->