### PR TITLE
feat(layout): resizable left and AI summary panels (#55)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,9 @@ import AddFeedDialog from "./components/AddFeedDialog";
 import ExploreDialog from "./components/ExploreDialog";
 import PromptDialog from "./components/PromptDialog";
 import PlayerBar from "./components/PlayerBar";
+import ResizeHandle from "./components/ResizeHandle";
 import Icon from "./components/Icon";
+import { PANEL_BOUNDS } from "./store";
 
 // Accent palettes — ported from the design prototype (app.jsx ACCENTS).
 const ACCENTS: Record<
@@ -60,6 +62,9 @@ export default function App() {
   const readerSize = useUi((s) => s.readerSize);
   const readerLeading = useUi((s) => s.readerLeading);
   const readerWidth = useUi((s) => s.readerWidth);
+  const sidebarWidth = useUi((s) => s.sidebarWidth);
+  const listWidth = useUi((s) => s.listWidth);
+  const aiWidth = useUi((s) => s.aiWidth);
   const reduceMotion = useUi((s) => s.prefs.reduceMotion);
   const focusMode = useUi((s) => s.focusMode);
 
@@ -163,6 +168,17 @@ export default function App() {
     root.setProperty("--reader-leading", String(readerLeading / 100));
     root.setProperty("--reader-width", `${readerWidth}px`);
   }, [readerFont, readerSize, readerLeading, readerWidth]);
+
+  // ── apply the draggable pane widths as the grid/drawer CSS variables ──
+  // These drive `.window`'s grid columns and the AI drawer's width; the resize
+  // handles write to the store, the store persists, and this mirrors the value
+  // back onto the document root.
+  useEffect(() => {
+    const root = document.documentElement.style;
+    root.setProperty("--col-sidebar", `${sidebarWidth}px`);
+    root.setProperty("--col-list", `${listWidth}px`);
+    root.setProperty("--ai-width", `${aiWidth}px`);
+  }, [sidebarWidth, listWidth, aiWidth]);
 
   // ── toast ──
   // The store owns the queue; App owns only the dwell timer and the render.
@@ -458,6 +474,39 @@ export default function App() {
           />
           <ArticleList onToast={showToast} />
           <Reader onToast={showToast} />
+          {/* Pane resize handles. Hidden in focus mode (the sidebar + list are
+              hidden then, collapsing the grid to a single reader column). They
+              sit at the column boundaries via the `left` offset below. */}
+          {!focusMode && (
+            <>
+              <div
+                className="resize-handle-slot"
+                style={{ left: "var(--col-sidebar)" }}
+              >
+                <ResizeHandle
+                  width={sidebarWidth}
+                  side="right"
+                  min={PANEL_BOUNDS.sidebar.min}
+                  max={PANEL_BOUNDS.sidebar.max}
+                  onResize={(w) => useUi.getState().setPanel({ sidebarWidth: w })}
+                  label={t("app.resizeSidebar")}
+                />
+              </div>
+              <div
+                className="resize-handle-slot"
+                style={{ left: "calc(var(--col-sidebar) + var(--col-list))" }}
+              >
+                <ResizeHandle
+                  width={listWidth}
+                  side="right"
+                  min={PANEL_BOUNDS.list.min}
+                  max={PANEL_BOUNDS.list.max}
+                  onResize={(w) => useUi.getState().setPanel({ listWidth: w })}
+                  label={t("app.resizeList")}
+                />
+              </div>
+            </>
+          )}
         </div>
         <PlayerBar />
       </div>

--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import * as api from "../api";
 import { LANGUAGES } from "../i18n";
-import { useUi } from "../store";
+import { useUi, PANEL_BOUNDS } from "../store";
 import { usePlayer } from "../player";
 import { useTranslationJobs } from "../translation";
 import { useArticleActions } from "../hooks/articleActions";
@@ -18,6 +18,7 @@ import { tagColor } from "../lib/tagColors";
 import type { ArticleDetail } from "../types";
 import Icon from "./Icon";
 import TagPicker from "./TagPicker";
+import ResizeHandle from "./ResizeHandle";
 import HighlightLayer from "./HighlightLayer";
 import ContextMenu, { type MenuEntry } from "./ContextMenu";
 
@@ -1119,6 +1120,7 @@ function AIDrawer({
 }) {
   const { t } = useTranslation();
   const qc = useQueryClient();
+  const aiWidth = useUi((s) => s.aiWidth);
   // Initialised from the article's stored summary (if any). The parent keys
   // this component by article id, so a switch remounts it and re-runs this
   // initialiser — no separate "reset on article change" effect is needed.
@@ -1212,6 +1214,18 @@ function AIDrawer({
       // close button and content out of the tab order and the a11y tree.
       inert={!open}
     >
+      {/* Left-edge handle: dragging left widens the drawer. Hidden from the
+          a11y tree while the drawer is closed (the whole drawer is `inert`). */}
+      <div className="resize-handle-slot resize-handle-slot--inline">
+        <ResizeHandle
+          width={aiWidth}
+          side="left"
+          min={PANEL_BOUNDS.ai.min}
+          max={PANEL_BOUNDS.ai.max}
+          onResize={(w) => useUi.getState().setPanel({ aiWidth: w })}
+          label={t("reader.resizeAi")}
+        />
+      </div>
       <div className="ai-head">
         <span className="accent-ico">
           <Icon name="sparkle-fill" size={15} />

--- a/src/components/ResizeHandle.tsx
+++ b/src/components/ResizeHandle.tsx
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useRef } from "react";
+
+interface Props {
+  /** Pixel width of the pane this handle resizes, at drag start. */
+  width: number;
+  /** `right`: dragging right grows the pane (sidebar / list, handle on the
+   *  pane's right edge). `left`: dragging left grows the pane (the AI drawer,
+   *  handle on its left edge). */
+  side: "left" | "right";
+  /** Lower clamp for the resulting width (px). */
+  min: number;
+  /** Upper clamp for the resulting width (px). */
+  max: number;
+  /** Called continuously during the drag with the new, clamped width. */
+  onResize: (width: number) => void;
+  /** Accessible label for the separator. */
+  label: string;
+}
+
+/**
+ * A thin draggable separator between two panes. Implemented with native
+ * pointer events (no third-party resize library) to stay lightweight and match
+ * the project's hand-rolled interaction code.
+ *
+ * The drag is tracked from the pointer's start X and the pane's start width, so
+ * a slow first frame can't desync the handle from the cursor. Pointer capture
+ * keeps the drag alive even if the cursor outruns the 6px hit area, and the
+ * body `col-resize` cursor + a no-select guard make the gesture feel native.
+ */
+export default function ResizeHandle({ width, side, min, max, onResize, label }: Props) {
+  // Latest props in a ref so the move/up listeners (bound once per drag) always
+  // read fresh values without re-binding mid-drag.
+  const latest = useRef({ width, side, min, max, onResize });
+  latest.current = { width, side, min, max, onResize };
+
+  const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    // Ignore secondary buttons so a right-click context menu can't start a drag.
+    if (e.button !== 0) return;
+    e.preventDefault();
+    const startX = e.clientX;
+    const { width: startW } = latest.current;
+    const target = e.currentTarget;
+    target.setPointerCapture(e.pointerId);
+
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+
+    const move = (ev: PointerEvent) => {
+      const { side, min, max, onResize } = latest.current;
+      const dx = ev.clientX - startX;
+      // `right` panes grow as the cursor moves right; `left` panes (drawer on
+      // the right) grow as it moves left.
+      const raw = side === "right" ? startW + dx : startW - dx;
+      onResize(Math.min(max, Math.max(min, raw)));
+    };
+    const up = (ev: PointerEvent) => {
+      target.releasePointerCapture?.(ev.pointerId);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", up);
+    };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", up);
+  }, []);
+
+  // Keyboard a11y: arrow keys nudge the boundary in 16px steps for users who
+  // can't drag.
+  const onKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    const { width, side, min, max, onResize } = latest.current;
+    const step = e.shiftKey ? 48 : 16;
+    let delta = 0;
+    if (e.key === "ArrowLeft") delta = side === "right" ? -step : step;
+    else if (e.key === "ArrowRight") delta = side === "right" ? step : -step;
+    else return;
+    e.preventDefault();
+    onResize(Math.min(max, Math.max(min, width + delta)));
+  }, []);
+
+  // Belt-and-braces: if this handle unmounts mid-drag (e.g. focus mode hides
+  // the panes), make sure the global cursor/select overrides are cleared.
+  useEffect(() => {
+    return () => {
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+  }, []);
+
+  return (
+    <div
+      className="resize-handle"
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={label}
+      tabIndex={0}
+      onPointerDown={onPointerDown}
+      onKeyDown={onKeyDown}
+    />
+  );
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -96,6 +96,8 @@
     "noFolder": "No folder"
   },
   "app": {
+    "resizeSidebar": "Resize sidebar",
+    "resizeList": "Resize article list",
     "refreshing": "Refreshing all feeds…",
     "foundNew": "Found {{count}} new articles",
     "upToDate": "Up to date",
@@ -156,6 +158,7 @@
     "footerHint": "Articles · Feeds · Commands"
   },
   "reader": {
+    "resizeAi": "Resize AI summary panel",
     "fullTextExtracted": "Full text extracted",
     "linkCopied": "Link copied",
     "ctxCopy": "Copy",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -96,6 +96,8 @@
     "noFolder": "フォルダなし"
   },
   "app": {
+    "resizeSidebar": "サイドバーの幅を調整",
+    "resizeList": "記事リストの幅を調整",
     "refreshing": "すべてのフィードを更新中…",
     "foundNew": "新着記事 {{count}} 件",
     "upToDate": "最新です",
@@ -156,6 +158,7 @@
     "footerHint": "記事 · フィード · コマンド"
   },
   "reader": {
+    "resizeAi": "AI 要約パネルの幅を調整",
     "fullTextExtracted": "全文を抽出しました",
     "linkCopied": "リンクをコピーしました",
     "ctxCopy": "コピー",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -96,6 +96,8 @@
     "noFolder": "不归入文件夹"
   },
   "app": {
+    "resizeSidebar": "调整侧栏宽度",
+    "resizeList": "调整文章列表宽度",
     "refreshing": "正在刷新所有订阅源…",
     "foundNew": "发现 {{count}} 篇新文章",
     "upToDate": "已是最新",
@@ -156,6 +158,7 @@
     "footerHint": "支持文章 · 订阅源 · 命令"
   },
   "reader": {
+    "resizeAi": "调整 AI 摘要面板宽度",
     "fullTextExtracted": "已提取全文",
     "linkCopied": "链接已复制",
     "ctxCopy": "复制",

--- a/src/store.ts
+++ b/src/store.ts
@@ -36,6 +36,17 @@ export const READER_BOUNDS = {
   width: { min: 520, max: 840 },
 } as const;
 
+/** Valid ranges for the draggable pane widths — shared by the resize handles,
+ *  persistence validation, and the `setPanel` write guard so all stay in
+ *  lockstep (mirrors `READER_BOUNDS`). The article-list column and the AI
+ *  drawer can grow wide, but never so far they crowd out the reader; the
+ *  sidebar stays a navigation rail. */
+export const PANEL_BOUNDS = {
+  sidebar: { min: 200, max: 420 },
+  list: { min: 300, max: 560 },
+  ai: { min: 280, max: 560 },
+} as const;
+
 /** Clamp `n` into `[min, max]`. */
 function clamp(n: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, n));
@@ -108,6 +119,11 @@ interface UiState {
   readerLeading: number;
   readerWidth: number;
 
+  // draggable pane widths (px)
+  sidebarWidth: number;
+  listWidth: number;
+  aiWidth: number;
+
   // behavioural preferences
   prefs: Prefs;
 
@@ -127,6 +143,7 @@ interface UiState {
   setViewMode: (v: ViewMode) => void;
   setReaderFont: (v: ReaderFont) => void;
   setReader: (p: Partial<Pick<UiState, "readerSize" | "readerLeading" | "readerWidth">>) => void;
+  setPanel: (p: Partial<Pick<UiState, "sidebarWidth" | "listWidth" | "aiWidth">>) => void;
 
   setPref: (patch: Partial<Prefs>) => void;
 
@@ -218,6 +235,10 @@ export const useUi = create<UiState>((set) => ({
   ),
   readerWidth: ls.num("readerWidth", 680, READER_BOUNDS.width.min, READER_BOUNDS.width.max),
 
+  sidebarWidth: ls.num("sidebarWidth", 248, PANEL_BOUNDS.sidebar.min, PANEL_BOUNDS.sidebar.max),
+  listWidth: ls.num("listWidth", 388, PANEL_BOUNDS.list.min, PANEL_BOUNDS.list.max),
+  aiWidth: ls.num("aiWidth", 360, PANEL_BOUNDS.ai.min, PANEL_BOUNDS.ai.max),
+
   prefs: loadPrefs(),
 
   focusMode: false,
@@ -258,6 +279,25 @@ export const useUi = create<UiState>((set) => ({
     if (p.readerWidth != null) {
       next.readerWidth = clamp(p.readerWidth, READER_BOUNDS.width.min, READER_BOUNDS.width.max);
       ls.set("readerWidth", next.readerWidth);
+    }
+    set(next);
+  },
+  setPanel: (p) => {
+    // Clamp on write so neither a drag past the handle's guard nor a stale
+    // persisted value (from an older build with different limits) can push an
+    // out-of-range width into the store or its `--col-*` CSS variable.
+    const next: Partial<Pick<UiState, "sidebarWidth" | "listWidth" | "aiWidth">> = {};
+    if (p.sidebarWidth != null) {
+      next.sidebarWidth = clamp(p.sidebarWidth, PANEL_BOUNDS.sidebar.min, PANEL_BOUNDS.sidebar.max);
+      ls.set("sidebarWidth", next.sidebarWidth);
+    }
+    if (p.listWidth != null) {
+      next.listWidth = clamp(p.listWidth, PANEL_BOUNDS.list.min, PANEL_BOUNDS.list.max);
+      ls.set("listWidth", next.listWidth);
+    }
+    if (p.aiWidth != null) {
+      next.aiWidth = clamp(p.aiWidth, PANEL_BOUNDS.ai.min, PANEL_BOUNDS.ai.max);
+      ls.set("aiWidth", next.aiWidth);
     }
     set(next);
   },

--- a/src/styles.css
+++ b/src/styles.css
@@ -205,6 +205,66 @@ button { font-family: inherit; }
   transition: background .35s ease, color .25s ease;
 }
 
+/* ====== Pane resize handles ====== */
+/* A handle is a thin draggable strip straddling a pane boundary. The two grid
+   boundaries (sidebar|list, list|reader) are positioned by an absolute slot
+   anchored to the column offset; the AI-drawer handle lives inline on the
+   drawer's own left edge. The strip is 7px wide for an easy grab target but
+   draws only a 1px line on hover/focus so it stays visually quiet. */
+.resize-handle-slot {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 0;
+  z-index: 6;            /* above the panes, below modals/toasts */
+  pointer-events: none;  /* only the handle itself is interactive */
+}
+.resize-handle-slot--inline {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 6;
+  width: 0;
+  pointer-events: none;
+}
+.resize-handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -3px;            /* centre the 7px strip on the boundary */
+  width: 7px;
+  cursor: col-resize;
+  pointer-events: auto;
+  touch-action: none;
+  /* The visible line: drawn as a centred 1px pseudo-element so the wide hit
+     area stays invisible until hover/focus. */
+  background: transparent;
+  transition: background .12s ease;
+}
+.resize-handle::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 3px;
+  width: 1px;
+  background: transparent;
+  transition: background .12s ease;
+}
+.resize-handle:hover::after,
+.resize-handle:focus-visible::after,
+.resize-handle:active::after {
+  background: var(--accent);
+}
+.resize-handle:focus-visible {
+  outline: none;
+}
+[data-reduce-motion="true"] .resize-handle,
+[data-reduce-motion="true"] .resize-handle::after {
+  transition: none;
+}
+
 .titlebar {
   position: absolute;
   top: 0; left: 0; right: 0;
@@ -875,7 +935,7 @@ button { font-family: inherit; }
 .ai-drawer {
   position: absolute;
   top: 38px; right: 0; bottom: 0;
-  width: 360px;
+  width: var(--ai-width, 360px);
   background: var(--panel);
   border-left: 1px solid var(--hair);
   transform: translateX(100%);


### PR DESCRIPTION
Closes #55

## 评估
合理。三栏 CSS Grid 布局宽度原本写死；项目已有 zustand+localStorage 持久化基础设施可复用。

## 实现
未引入第三方库，用原生 Pointer 事件 + 可复用 `ResizeHandle` 组件。新增 `sidebarWidth`/`listWidth`/`aiWidth` 持久化字段（带 clamp 与最小/最大限制），通过 CSS 变量驱动；支持键盘可访问性；补三语 i18n。

## 验证
`pnpm build` 通过；`pnpm test` 70 个测试全过。

改动文件：`src/store.ts`、`src/App.tsx`、`src/components/Reader.tsx`、`src/components/ResizeHandle.tsx`(新增)、`src/styles.css`、`src/locales/{en,zh,ja}.json`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Sidebar, document list, and AI summary panels are now resizable via draggable handles
* Custom panel widths persist automatically between sessions
* Keyboard navigation support: use arrow keys to adjust panel sizes (Shift for larger adjustments)
* Multi-language support for resize controls added

<!-- end of auto-generated comment: release notes by coderabbit.ai -->