### PR TITLE
feat(ai): add DeepSeek API provider support (#56)

### DIFF
--- a/src-tauri/src/ai.rs
+++ b/src-tauri/src/ai.rs
@@ -62,6 +62,10 @@ pub enum AiEvent {
 enum Provider {
     Anthropic,
     OpenAi,
+    /// DeepSeek exposes an OpenAI-compatible API (same `/chat/completions`
+    /// endpoint, request body and SSE shape), so it reuses the OpenAI request
+    /// and parsing paths; only the default base URL and model differ.
+    DeepSeek,
 }
 
 /// Resolved AI configuration read from the settings table.
@@ -96,6 +100,7 @@ impl AiConfig {
             .ok_or_else(|| AppError::code("noAiKey"))?;
         let provider = match provider.as_deref() {
             Some("openai") => Provider::OpenAi,
+            Some("deepseek") => Provider::DeepSeek,
             _ => Provider::Anthropic,
         };
         // Likewise trim the model name — it is JSON-serialised into the
@@ -106,6 +111,7 @@ impl AiConfig {
             .unwrap_or_else(|| match provider {
                 Provider::Anthropic => "claude-sonnet-4-6".to_string(),
                 Provider::OpenAi => "gpt-4.1-mini".to_string(),
+                Provider::DeepSeek => "deepseek-chat".to_string(),
             });
         let base_url = base_url
             .map(|u| u.trim().trim_end_matches('/').to_string())
@@ -127,7 +133,17 @@ impl Provider {
         match self {
             Provider::Anthropic => "https://api.anthropic.com/v1",
             Provider::OpenAi => "https://api.openai.com/v1",
+            // DeepSeek serves the OpenAI-compatible API at this root; our code
+            // appends `/chat/completions`.
+            Provider::DeepSeek => "https://api.deepseek.com",
         }
+    }
+
+    /// Whether this provider speaks the Anthropic or the OpenAI wire format
+    /// (request body, endpoint path, and SSE shape). DeepSeek is
+    /// OpenAI-compatible, so it shares OpenAI's request and parsing paths.
+    fn is_openai_compatible(self) -> bool {
+        matches!(self, Provider::OpenAi | Provider::DeepSeek)
     }
 }
 
@@ -151,13 +167,10 @@ pub async fn stream_chat(
     channel: &Channel<AiEvent>,
     max_tokens: u32,
 ) -> AppResult<ChatOutcome> {
-    let result = match cfg.provider {
-        Provider::Anthropic => {
-            stream_anthropic(client, cfg, system, user, Some(channel), max_tokens).await
-        }
-        Provider::OpenAi => {
-            stream_openai(client, cfg, system, user, Some(channel), max_tokens).await
-        }
+    let result = if cfg.provider.is_openai_compatible() {
+        stream_openai(client, cfg, system, user, Some(channel), max_tokens).await
+    } else {
+        stream_anthropic(client, cfg, system, user, Some(channel), max_tokens).await
     };
     match &result {
         Ok(_) => {
@@ -181,11 +194,10 @@ pub async fn complete_chat(
     user: &str,
     max_tokens: u32,
 ) -> AppResult<String> {
-    let outcome = match cfg.provider {
-        Provider::Anthropic => {
-            stream_anthropic(client, cfg, system, user, None, max_tokens).await
-        }
-        Provider::OpenAi => stream_openai(client, cfg, system, user, None, max_tokens).await,
+    let outcome = if cfg.provider.is_openai_compatible() {
+        stream_openai(client, cfg, system, user, None, max_tokens).await
+    } else {
+        stream_anthropic(client, cfg, system, user, None, max_tokens).await
     }?;
     Ok(outcome.text)
 }
@@ -353,7 +365,10 @@ async fn consume_sse(
 fn extract_error(v: &Value, provider: Provider) -> Option<String> {
     let err = match provider {
         Provider::Anthropic => (v["type"] == "error").then(|| &v["error"]),
-        Provider::OpenAi => v.get("error").filter(|e| e.is_object()),
+        // DeepSeek is OpenAI-compatible; in practice it always reaches this
+        // function tagged as `OpenAi` (see `stream_openai`), but handle it
+        // identically so the match stays exhaustive.
+        Provider::OpenAi | Provider::DeepSeek => v.get("error").filter(|e| e.is_object()),
     }?;
     Some(
         err["message"]
@@ -373,7 +388,8 @@ fn extract_delta(v: &Value, provider: Provider) -> Option<String> {
                 None
             }
         }
-        Provider::OpenAi => v["choices"][0]["delta"]["content"]
+        // DeepSeek shares the OpenAI SSE shape; see the note in `extract_error`.
+        Provider::OpenAi | Provider::DeepSeek => v["choices"][0]["delta"]["content"]
             .as_str()
             .map(String::from),
     }
@@ -555,6 +571,32 @@ mod tests {
             Ok(_) => panic!("a whitespace-only key must not be accepted"),
             Err(e) => assert!(e.to_string().contains("noAiKey")),
         }
+    }
+
+    #[test]
+    fn deepseek_provider_uses_its_own_defaults_and_openai_wire_format() {
+        // DeepSeek has no model or base URL set, so it must fall back to its
+        // own defaults — not OpenAI's — while still speaking the OpenAI wire
+        // format (it is OpenAI-compatible).
+        let cfg = AiConfig::new(Some("deepseek".into()), Some("sk-key".into()), None, None)
+            .unwrap();
+        assert_eq!(cfg.model, "deepseek-chat");
+        assert_eq!(cfg.base_url, "https://api.deepseek.com");
+        assert!(cfg.provider.is_openai_compatible());
+    }
+
+    #[test]
+    fn deepseek_honours_a_custom_base_url() {
+        let cfg = AiConfig::new(
+            Some("deepseek".into()),
+            Some("sk-key".into()),
+            Some("deepseek-reasoner".into()),
+            Some("https://proxy.example.com/v1/".into()),
+        )
+        .unwrap();
+        assert_eq!(cfg.model, "deepseek-reasoner");
+        // Trailing slash trimmed, as for every provider.
+        assert_eq!(cfg.base_url, "https://proxy.example.com/v1");
     }
 
     #[test]

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -1636,7 +1636,9 @@ type TranslateEngine = "llm" | "google" | "deepl" | "bing";
 function AiSettingsGroup({ onToast }: { onToast: (m: string) => void }) {
   const { t, i18n } = useTranslation();
   const qc = useQueryClient();
-  const [provider, setProvider] = useState<"anthropic" | "openai">("anthropic");
+  const [provider, setProvider] = useState<"anthropic" | "openai" | "deepseek">(
+    "anthropic",
+  );
   const [apiKey, setApiKey] = useState("");
   const [model, setModel] = useState("");
   const [baseUrl, setBaseUrl] = useState("");
@@ -1658,7 +1660,8 @@ function AiSettingsGroup({ onToast }: { onToast: (m: string) => void }) {
       api.getSetting("translate_target_lang"),
     ])
       .then(([p, k, m, b, eng, tl]) => {
-        if (p === "openai" || p === "anthropic") setProvider(p);
+        if (p === "openai" || p === "anthropic" || p === "deepseek")
+          setProvider(p);
         if (k) {
           setApiKey(k);
           savedKey.current = k;
@@ -1688,12 +1691,16 @@ function AiSettingsGroup({ onToast }: { onToast: (m: string) => void }) {
   const placeholder =
     provider === "openai"
       ? t("settings.advanced.aiModelPlaceholderOpenai")
-      : t("settings.advanced.aiModelPlaceholderAnthropic");
+      : provider === "deepseek"
+        ? t("settings.advanced.aiModelPlaceholderDeepseek")
+        : t("settings.advanced.aiModelPlaceholderAnthropic");
 
   const baseUrlPlaceholder =
     provider === "openai"
       ? "https://api.openai.com/v1"
-      : "https://api.anthropic.com/v1";
+      : provider === "deepseek"
+        ? "https://api.deepseek.com"
+        : "https://api.anthropic.com/v1";
 
   return (
     <div className="settings-group">
@@ -1707,6 +1714,7 @@ function AiSettingsGroup({ onToast }: { onToast: (m: string) => void }) {
           options={[
             { value: "anthropic", label: "Anthropic" },
             { value: "openai", label: "OpenAI" },
+            { value: "deepseek", label: "DeepSeek" },
           ]}
           onChange={(v) => {
             setProvider(v);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -474,6 +474,7 @@
       "aiModelLabel": "AI model",
       "aiModelPlaceholderOpenai": "gpt-4.1-mini (default)",
       "aiModelPlaceholderAnthropic": "claude-sonnet-4-6 (default)",
+      "aiModelPlaceholderDeepseek": "deepseek-chat (default)",
       "aiBaseUrl": "Base URL",
       "aiBaseUrlDesc": "API endpoint root. Leave blank for the provider's official endpoint, or point to any compatible provider (OpenRouter, Groq, DeepSeek, a local server)",
       "aiBaseUrlLabel": "Base URL",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -474,6 +474,7 @@
       "aiModelLabel": "AI モデル",
       "aiModelPlaceholderOpenai": "gpt-4.1-mini（既定）",
       "aiModelPlaceholderAnthropic": "claude-sonnet-4-6（既定）",
+      "aiModelPlaceholderDeepseek": "deepseek-chat（既定）",
       "aiBaseUrl": "ベース URL",
       "aiBaseUrlDesc": "API エンドポイントのルート。空欄で公式エンドポイントを使用。互換プロバイダー（OpenRouter、Groq、DeepSeek、ローカルサーバーなど）も指定できます",
       "aiBaseUrlLabel": "ベース URL",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -474,6 +474,7 @@
       "aiModelLabel": "AI 模型",
       "aiModelPlaceholderOpenai": "gpt-4.1-mini（默认）",
       "aiModelPlaceholderAnthropic": "claude-sonnet-4-6（默认）",
+      "aiModelPlaceholderDeepseek": "deepseek-chat（默认）",
       "aiBaseUrl": "Base URL",
       "aiBaseUrlDesc": "API 端点根地址。留空则使用官方端点，也可指向任意兼容服务商（OpenRouter、Groq、DeepSeek、本地服务等）",
       "aiBaseUrlLabel": "Base URL",


### PR DESCRIPTION
Closes #56

## 评估
非常合理、成本极低。后端 `ai.rs` 本就是 provider 抽象 + 自定义 baseURL + OpenAI 兼容设计。本次把 DeepSeek 提升为一等预设选项。

## 实现
新增 `Provider::DeepSeek`（默认 baseURL `https://api.deepseek.com`、模型 `deepseek-chat`），复用 OpenAI 的请求/SSE 解析路径；前端下拉、占位符、三语文案补齐。`deepseek-reasoner` 等可在模型框自填。

## 验证
`pnpm build` 通过；`cargo test ai::` 16 个全过（含 2 个新测试）；`cargo clippy` 无警告。

改动文件：`src-tauri/src/ai.rs`、`src/components/SettingsDialog.tsx`、`src/locales/{en,zh,ja}.json`。