### PR TITLE
feat(translation): per-feed auto-translate toggle (#57)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -197,6 +197,7 @@ pub async fn add_feed(
         fetch_error: None,
         unread_count: unread,
         refresh_interval_min: None,
+        auto_translate: false,
     })
 }
 
@@ -275,6 +276,18 @@ pub async fn set_feed_refresh_interval(
 ) -> AppResult<()> {
     let conn = state.db.lock().await;
     db::set_feed_refresh_interval(&conn, id, minutes)
+}
+
+/// Toggle a feed's auto-translate flag. When on, opening any article from this
+/// feed automatically translates it into the configured target language.
+#[tauri::command]
+pub async fn set_feed_auto_translate(
+    state: State<'_, AppState>,
+    id: i64,
+    enabled: bool,
+) -> AppResult<()> {
+    let conn = state.db.lock().await;
+    db::set_feed_auto_translate(&conn, id, enabled)
 }
 
 #[tauri::command]
@@ -1275,6 +1288,7 @@ pub async fn add_newsletter_source(
         fetch_error: None,
         unread_count: unread,
         refresh_interval_min: None,
+        auto_translate: false,
     })
 }
 

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -245,6 +245,12 @@ static MIGRATIONS: LazyLock<Migrations> = LazyLock::new(|| {
         // v15 — per-feed refresh interval (minutes). NULL follows the global
         // `refresh_interval_min` setting; the 525_600 sentinel means "never".
         M::up("ALTER TABLE feeds ADD COLUMN refresh_interval_min INTEGER;"),
+        // v16 — per-feed auto-translate. 0 (the default) shows the original
+        // text; 1 translates an article into the configured target language the
+        // moment it is opened.
+        M::up(
+            "ALTER TABLE feeds ADD COLUMN auto_translate INTEGER NOT NULL DEFAULT 0;",
+        ),
     ])
 });
 
@@ -462,7 +468,7 @@ pub fn list_feeds(conn: &Connection) -> AppResult<Vec<Feed>> {
         "SELECT f.id, f.feed_url, f.site_url, f.title, f.description, f.favicon_url,
                 f.folder_id, f.source_type, f.last_fetched_at, f.fetch_error,
                 (SELECT COUNT(*) FROM articles a WHERE a.feed_id = f.id AND a.is_read = 0),
-                f.refresh_interval_min
+                f.refresh_interval_min, f.auto_translate
          FROM feeds f ORDER BY f.title COLLATE NOCASE",
     )?;
     let rows = stmt
@@ -480,6 +486,7 @@ pub fn list_feeds(conn: &Connection) -> AppResult<Vec<Feed>> {
                 fetch_error: r.get(9)?,
                 unread_count: r.get(10)?,
                 refresh_interval_min: r.get(11)?,
+                auto_translate: r.get::<_, i64>(12)? != 0,
             })
         })?
         .collect::<Result<Vec<_>, _>>()?;
@@ -545,6 +552,16 @@ pub fn set_feed_refresh_interval(
     conn.execute(
         "UPDATE feeds SET refresh_interval_min = ?2 WHERE id = ?1",
         params![id, minutes],
+    )?;
+    Ok(())
+}
+
+/// Toggle a feed's per-feed auto-translate flag. When on, opening an article
+/// from this feed starts a translation into the configured target language.
+pub fn set_feed_auto_translate(conn: &Connection, id: i64, enabled: bool) -> AppResult<()> {
+    conn.execute(
+        "UPDATE feeds SET auto_translate = ?2 WHERE id = ?1",
+        params![id, enabled as i64],
     )?;
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -234,6 +234,7 @@ pub fn run() {
             commands::delete_feed,
             commands::move_feed,
             commands::set_feed_refresh_interval,
+            commands::set_feed_auto_translate,
             commands::rename_feed,
             commands::refresh_feeds,
             commands::list_articles,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -58,6 +58,10 @@ pub struct Feed {
     /// Per-feed refresh interval in minutes. `None` follows the global
     /// `refresh_interval_min` setting; the `525_600` sentinel means "never".
     pub refresh_interval_min: Option<i64>,
+    /// When `true`, opening an article from this feed automatically starts a
+    /// translation into the configured target language. Off by default, so
+    /// existing feeds keep showing the original text.
+    pub auto_translate: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/api.ts
+++ b/src/api.ts
@@ -63,6 +63,10 @@ export const renameFeed = (id: number, title: string) =>
  *  setting; `525600` opts the feed out of automatic refresh. */
 export const setFeedRefreshInterval = (id: number, minutes: number | null) =>
   invoke<void>("set_feed_refresh_interval", { id, minutes });
+/** Toggle a feed's auto-translate flag. When on, opening an article from the
+ *  feed translates it into the configured target language straight away. */
+export const setFeedAutoTranslate = (id: number, enabled: boolean) =>
+  invoke<void>("set_feed_auto_translate", { id, enabled });
 
 /** Refresh all feeds, reporting progress through the supplied callback. */
 export function refreshFeeds(

--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -209,6 +209,13 @@ export default function Reader({ onToast }: Props) {
   });
   const a: ArticleDetail | undefined = article.data;
 
+  // Feed list, so the article's source feed can be checked for its per-feed
+  // auto-translate flag. Shared cache key with the sidebar — no extra fetch.
+  const feeds = useQuery({ queryKey: ["feeds"], queryFn: api.listFeeds });
+  const autoTranslateFeed = !!(
+    a && feeds.data?.find((f) => f.id === a.feedId)?.autoTranslate
+  );
+
   const readMinutes = useMemo(() => {
     return estimateReadMinutes(bodyPlainText(a?.extractedHtml || a?.contentHtml || ""));
     // Recompute when the body changes — including after full-text extraction
@@ -515,6 +522,27 @@ export default function Reader({ onToast }: Props) {
     extract.mutate(a.id);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [a?.id, a?.extractedHtml, autoExtract]);
+
+  // Per-feed auto-translate: when the article's source feed opts in, translate
+  // it into the configured target the moment it opens. Fires once per article
+  // (guarded by `autoTranslatedRef`), only when there's a body to translate and
+  // a usable cached translation in the target language isn't already present —
+  // so a feed left untouched still shows its original text, and reopening a
+  // cached article doesn't re-spend an API call. The toolbar toggle still lets
+  // the reader flip back to the original at any time.
+  const autoTranslatedRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (!autoTranslateFeed || !a || !canTranslate) return;
+    if (autoTranslatedRef.current === a.id) return;
+    autoTranslatedRef.current = a.id;
+    // A fresh cached translation for the target language needs no new job;
+    // just surface it. Otherwise start a background translation.
+    if (!(a.translatedHtml && a.translatedLang === targetLang)) {
+      startTranslate(a.id, targetLang, engine);
+    }
+    setShowTranslation(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [a?.id, autoTranslateFeed, canTranslate, targetLang, engine]);
 
   // Mark the current article read once its foot is reached. Also fires for an
   // article short enough to need no scrolling at all (`scrollHeight` already

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -819,6 +819,14 @@ function SubscriptionsSection({
       .then(() => qc.invalidateQueries({ queryKey: ["feeds"] }))
       .catch((e) => reportError(e));
   };
+  // Per-feed auto-translate: opening an article from a feed with this on
+  // translates it into the configured target language straight away.
+  const updateAutoTranslate = (f: Feed, enabled: boolean) => {
+    api
+      .setFeedAutoTranslate(f.id, enabled)
+      .then(() => qc.invalidateQueries({ queryKey: ["feeds"] }))
+      .catch((e) => reportError(e));
+  };
 
   const exportOpml = async () => {
     try {
@@ -922,6 +930,17 @@ function SubscriptionsSection({
               <span className="name">{f.title}</span>
               <span className="url">{feedHost(f)}</span>
               <div className="actions">
+                <label
+                  className="s-feed-autotr"
+                  title={t("settings.subscriptions.autoTranslateDesc")}
+                >
+                  <Icon name="globe" size={13} color="var(--muted)" />
+                  <Toggle
+                    checked={f.autoTranslate}
+                    onChange={(v) => updateAutoTranslate(f, v)}
+                    aria-label={t("settings.subscriptions.autoTranslate")}
+                  />
+                </label>
                 <Select
                   value={intervalValue(f.refreshIntervalMin)}
                   options={intervalOptions}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -311,6 +311,8 @@
       "refresh12h": "Every 12 hours",
       "refresh1d": "Every day",
       "refreshOff": "Never",
+      "autoTranslate": "Auto-translate",
+      "autoTranslateDesc": "Translate articles from this feed automatically when opened",
       "unsubscribe": "Unsubscribe",
       "noMatch": "No matching feeds.",
       "opmlExported": "OPML exported to the Downloads folder",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -311,6 +311,8 @@
       "refresh12h": "12時間ごと",
       "refresh1d": "1日ごと",
       "refreshOff": "なし",
+      "autoTranslate": "自動翻訳",
+      "autoTranslateDesc": "このフィードの記事を開いたときに自動的に翻訳します",
       "unsubscribe": "購読解除",
       "noMatch": "一致するフィードがありません。",
       "opmlExported": "OPML をダウンロードフォルダにエクスポートしました",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -311,6 +311,8 @@
       "refresh12h": "每 12 小时",
       "refresh1d": "每天",
       "refreshOff": "从不",
+      "autoTranslate": "自动翻译",
+      "autoTranslateDesc": "打开此订阅源的文章时自动翻译",
       "unsubscribe": "退订",
       "noMatch": "没有匹配的订阅源。",
       "opmlExported": "OPML 已导出到下载文件夹",

--- a/src/styles.css
+++ b/src/styles.css
@@ -1646,6 +1646,7 @@ button { font-family: inherit; }
 .s-feed-row .url { color: var(--muted); font-size: 12px; font-family: var(--mono); flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .s-feed-row .actions { display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
 .s-feed-row .actions .s-select { padding-top: 3px; padding-bottom: 3px; }
+.s-feed-row .s-feed-autotr { display: inline-flex; align-items: center; gap: 5px; cursor: pointer; }
 .s-feed-row .icon-btn {
   width: 26px; height: 26px;
   background: none; border: 0;

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,9 @@ export interface Feed {
   /** Per-feed refresh interval in minutes. `null` follows the global
    *  setting; the `525600` sentinel means "never". */
   refreshIntervalMin: number | null;
+  /** When true, opening an article from this feed auto-translates it into the
+   *  configured target language. Defaults to false (show the original). */
+  autoTranslate: boolean;
 }
 
 export interface Enclosure {


### PR DESCRIPTION
Closes #57

## 评估
合理。项目已有逐源设置先例 `refresh_interval_min`，严格复刻该范式。

## 实现
DB v16 迁移加 `auto_translate` 字段（默认关闭，向后兼容）；后端模型/命令贯通；设置 UI 每源行加"自动翻译"开关；Reader 打开文章时若该源开启则自动触发现有翻译逻辑（每篇只触发一次、有缓存不重复消耗 API）；补三语 i18n。

## 验证
`pnpm build` 通过；`cargo check` 通过；`cargo test db::` 56 项全过。

改动文件：`src-tauri/src/{models,db,commands,lib}.rs`、`src/types.ts`、`src/api.ts`、`src/components/{SettingsDialog,Reader}.tsx`、`src/styles.css`、`src/locales/{en,zh,ja}.json`。