### PR TITLE
feat(sidebar): unread-only filter for subscription list (#58)

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -94,6 +94,8 @@ export default function Sidebar({
   const query = useUi((s) => s.query);
   const select = useUi((s) => s.select);
   const showCounts = useUi((s) => s.prefs.showSidebarCounts);
+  const unreadOnly = useUi((s) => s.prefs.sidebarUnreadOnly);
+  const setPref = useUi((s) => s.setPref);
 
   const feeds = useQuery({ queryKey: ["feeds"], queryFn: api.listFeeds });
   const folders = useQuery({ queryKey: ["folders"], queryFn: api.listFolders });
@@ -198,8 +200,19 @@ export default function Sidebar({
   const allFeeds = feeds.data ?? [];
   const allFolders = folders.data ?? [];
   const allTags = tags.data ?? [];
-  const ungrouped = allFeeds.filter((f) => f.folderId == null);
   const isActive = (q: ArticleQuery) => sameQuery(q, query);
+
+  // "Unread only" hides feeds with nothing unread, decluttering large
+  // sidebars. The currently-selected feed is always kept so it doesn't vanish
+  // from under the user the moment its last article is marked read, and the
+  // filter is suspended mid-drag so a drag target never disappears.
+  const feedVisible = (f: Feed) =>
+    !unreadOnly ||
+    dragId != null ||
+    f.unreadCount > 0 ||
+    isActive({ kind: "feed", value: f.id });
+  const visibleFeeds = allFeeds.filter(feedVisible);
+  const ungrouped = visibleFeeds.filter((f) => f.folderId == null);
 
   // ── drag to move a feed between folders ──
   const handleDrop = (target: number | null) => {
@@ -538,6 +551,15 @@ export default function Sidebar({
           <span>{t("sidebar.feeds")}</span>
           <span className="sb-section-actions">
             <button
+              className={unreadOnly ? "active" : ""}
+              onClick={() => setPref({ sidebarUnreadOnly: !unreadOnly })}
+              title={t("sidebar.unreadOnly")}
+              aria-label={t("sidebar.unreadOnly")}
+              aria-pressed={unreadOnly}
+            >
+              <Icon name={unreadOnly ? "eye-off" : "eye"} size={12} />
+            </button>
+            <button
               onClick={createFolder}
               title={t("app.newFolderTitle")}
               aria-label={t("app.newFolderTitle")}
@@ -564,6 +586,19 @@ export default function Sidebar({
             }}
           >
             {t("sidebar.emptyHint")}
+          </div>
+        )}
+
+        {allFeeds.length > 0 && unreadOnly && visibleFeeds.length === 0 && (
+          <div
+            style={{
+              padding: "10px 12px",
+              fontSize: 12,
+              color: "var(--muted)",
+              lineHeight: 1.5,
+            }}
+          >
+            {t("sidebar.allReadHint")}
           </div>
         )}
 
@@ -597,7 +632,11 @@ export default function Sidebar({
         )}
 
         {allFolders.map((folder) => {
-          const inFolder = allFeeds.filter((f) => f.folderId === folder.id);
+          const inFolder = visibleFeeds.filter((f) => f.folderId === folder.id);
+          // In "unread only" mode an empty folder is hidden — unless a drag is
+          // active, when it must stay as a drop target.
+          if (unreadOnly && dragId == null && inFolder.length === 0)
+            return null;
           const isCollapsed = collapsed[folder.id];
           // Aggregate unread for the folder. Shown only while collapsed —
           // expanded, the per-feed badges already carry the same signal, and a

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -499,6 +499,8 @@
     "feeds": "Feeds",
     "addFeed": "Add feed",
     "emptyHint": "No feeds yet. Click + to add one.",
+    "unreadOnly": "Show unread only",
+    "allReadHint": "No unread feeds — all caught up.",
     "feedError": "Update failed",
     "uncategorized": "Uncategorized",
     "dropUngroup": "Drop here to remove from folder",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -499,6 +499,8 @@
     "feeds": "フィード",
     "addFeed": "フィードを追加",
     "emptyHint": "フィードがまだありません。+ をクリックして追加してください。",
+    "unreadOnly": "未読のみ表示",
+    "allReadHint": "未読のフィードはありません — すべて既読です。",
     "feedError": "更新に失敗しました",
     "uncategorized": "未分類",
     "dropUngroup": "ここにドロップしてフォルダから外す",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -499,6 +499,8 @@
     "feeds": "订阅源",
     "addFeed": "添加订阅源",
     "emptyHint": "还没有订阅源。点击 + 添加一个。",
+    "unreadOnly": "仅显示未读",
+    "allReadHint": "没有未读的订阅源 — 已全部读完。",
     "feedError": "更新失败",
     "uncategorized": "未分类",
     "dropUngroup": "拖到此处移出文件夹",

--- a/src/store.ts
+++ b/src/store.ts
@@ -52,6 +52,8 @@ export interface Prefs {
   autoExtract: boolean;
   startupView: StartupView;
   hideReadOnStartup: boolean;
+  /** Sidebar "unread only" mode — hide feeds with no unread articles. */
+  sidebarUnreadOnly: boolean;
 }
 
 const ls = {
@@ -144,6 +146,7 @@ const PREF_KEYS: (keyof Prefs)[] = [
   "autoExtract",
   "startupView",
   "hideReadOnStartup",
+  "sidebarUnreadOnly",
 ];
 
 /** Mirror the active theme into the backend settings table so the Rust side
@@ -185,6 +188,7 @@ function loadPrefs(): Prefs {
       "unread",
     ),
     hideReadOnStartup: ls.bool("pref.hideReadOnStartup", false),
+    sidebarUnreadOnly: ls.bool("pref.sidebarUnreadOnly", false),
   };
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -318,6 +318,8 @@ button { font-family: inherit; }
   align-items: center;
 }
 .sb-section-title button:hover { background: var(--hover); color: var(--ink-2); }
+.sb-section-title button.active { color: var(--accent); }
+.sb-section-title button.active:hover { color: var(--accent); }
 
 .sb-item {
   display: flex;


### PR DESCRIPTION
Closes #58

## 评估
合理。`Feed` 类型已有 `unreadCount` 字段（后端直接返回），未读数徽标也已存在，实现成本极低。

## 实现
store 新增 `sidebarUnreadOnly` 偏好（localStorage 持久化）；Sidebar 标题区加眼睛图标切换按钮；过滤只显示 `unreadCount > 0` 的源，并做了稳健处理（保留当前选中源、拖拽时暂停过滤、全部已读显示提示）；补三语 i18n。

## 验证
`pnpm build` 通过。

改动文件：`src/store.ts`、`src/components/Sidebar.tsx`、`src/styles.css`、`src/locales/{en,zh,ja}.json`。