### PR TITLE
fix(layout): resize handle stops tracking cursor on macOS WebKit

### DIFF
--- a/src/components/ResizeHandle.tsx
+++ b/src/components/ResizeHandle.tsx
@@ -23,9 +23,16 @@ interface Props {
  * the project's hand-rolled interaction code.
  *
  * The drag is tracked from the pointer's start X and the pane's start width, so
- * a slow first frame can't desync the handle from the cursor. Pointer capture
- * keeps the drag alive even if the cursor outruns the 6px hit area, and the
- * body `col-resize` cursor + a no-select guard make the gesture feel native.
+ * a slow first frame can't desync the handle from the cursor. Move/up are bound
+ * on `window` so the drag survives the cursor outrunning the 7px hit area, and
+ * the body `col-resize` cursor + a no-select guard make the gesture feel native.
+ *
+ * We deliberately do NOT use `setPointerCapture`: the handle's slot moves every
+ * frame (its `left` tracks the live `--col-*` variable), and WebKit (the macOS
+ * Tauri webview) releases the capture whenever the captured element changes
+ * position — which dropped the drag and flickered the line mid-gesture. The
+ * handle draws no line on hover/drag now (the `col-resize` cursor is the
+ * affordance); only keyboard focus shows one, where capture loss can't apply.
  */
 export default function ResizeHandle({ width, side, min, max, onResize, label }: Props) {
   // Latest props in a ref so the move/up listeners (bound once per drag) always
@@ -40,7 +47,6 @@ export default function ResizeHandle({ width, side, min, max, onResize, label }:
     const startX = e.clientX;
     const { width: startW } = latest.current;
     const target = e.currentTarget;
-    target.setPointerCapture(e.pointerId);
 
     document.body.style.cursor = "col-resize";
     document.body.style.userSelect = "none";
@@ -53,8 +59,7 @@ export default function ResizeHandle({ width, side, min, max, onResize, label }:
       const raw = side === "right" ? startW + dx : startW - dx;
       onResize(Math.min(max, Math.max(min, raw)));
     };
-    const up = (ev: PointerEvent) => {
-      target.releasePointerCapture?.(ev.pointerId);
+    const up = () => {
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
       window.removeEventListener("pointermove", move);

--- a/src/components/ResizeHandle.tsx
+++ b/src/components/ResizeHandle.tsx
@@ -46,7 +46,6 @@ export default function ResizeHandle({ width, side, min, max, onResize, label }:
     e.preventDefault();
     const startX = e.clientX;
     const { width: startW } = latest.current;
-    const target = e.currentTarget;
 
     document.body.style.cursor = "col-resize";
     document.body.style.userSelect = "none";

--- a/src/styles.css
+++ b/src/styles.css
@@ -252,9 +252,9 @@ button { font-family: inherit; }
   background: transparent;
   transition: background .12s ease;
 }
-.resize-handle:hover::after,
-.resize-handle:focus-visible::after,
-.resize-handle:active::after {
+/* No visible line on hover/drag — the `col-resize` cursor is the affordance.
+   Keyboard focus still shows the accent line for a11y (no flicker there). */
+.resize-handle:focus-visible::after {
   background: var(--accent);
 }
 .resize-handle:focus-visible {


### PR DESCRIPTION
## 问题

调整面板大小时,分隔线那根强调色(黄)线会闪烁、且不跟随鼠标(#55 / PR #60 引入的回归在 macOS Tauri 上暴露)。

## 根因

`ResizeHandle` 在 `pointerdown` 时对 handle 元素调用了 `setPointerCapture`。但拖动过程中,handle 所在 slot 的 `left` 绑定到实时变化的 `--col-*` CSS 变量——也就是**被捕获的元素每一帧都在移动**。WebKit(macOS Tauri 用的 WKWebView)会在被捕获元素改变位置时**释放 pointer capture**,导致拖动中断、`:active` 反复得失,那根 accent 线随之闪烁。Chromium 无此行为,故普通浏览器/devtools 测不出来。

## 修复

- 移除 `setPointerCapture`/`releasePointerCapture`——`window` 级的 `pointermove`/`pointerup` 监听本就覆盖整个手势,capture 是多余的。
- 去掉 hover/拖动时的 accent 线(`col-resize` 光标已是足够的可拖提示);键盘 `:focus-visible` 仍保留焦点线(无障碍,且键盘场景不存在 capture 丢失)。

## 测试

macOS 本地 `tauri dev`:拖动侧栏/列表分隔线,面板边界连续跟随鼠标,无闪烁。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resize-handle drag stability in macOS/Tauri webviews by preventing flicker and mid-drag interruption related to native pointer-capture behavior.

* **Style**
  * Adjusted the resize handle’s accent line to display only on keyboard focus (focus-visible), avoiding extra visual cues during hover and dragging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->