### PR TITLE
Bump version to 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "papr",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.10.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "papr"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "papr"
-version = "0.9.0"
+version = "0.10.0"
 description = "Papr — a modern RSS reader"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Papr",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "identifier": "com.thomas.papr",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Release 0.10.0. 本次包含:

**新功能**
- feat(ai): DeepSeek API 提供商支持 (#56/#61)
- feat(translation): 按订阅源自动翻译开关 (#57/#62)
- feat(sidebar): 订阅列表「仅未读」筛选 (#58/#63)
- feat(layout): 可拖拽调整左侧/AI 摘要面板宽度 (#55/#60)

**修复**
- fix(reader): 打开弹窗时关闭原文 native webview,避免遮挡 (#54/#59)
- fix(tray): macOS 菜单栏未读计数线程修复 (#53)
- fix(layout): 修复 macOS WebKit 下 resize handle 不跟随鼠标/黄线闪烁 (#66)

bump package.json / Cargo.toml / Cargo.lock / tauri.conf.json → 0.10.0。