### PR TITLE
feat(reader): click the feed name to view all its articles (#68)

### DIFF
--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -856,10 +856,17 @@ export default function Reader({ onToast }: Props) {
         }}
       >
         <article className="article reader-content" key={a.id}>
-          <span className="article-feed">
+          <button
+            type="button"
+            className="article-feed"
+            title={t("reader.viewAllFromFeed")}
+            onClick={() =>
+              useUi.getState().select({ kind: "feed", value: a.feedId }, a.feedTitle)
+            }
+          >
             <Icon name="rss" size={13} />
             {a.feedTitle}
-          </span>
+          </button>
           <h1 className="article-title">{a.title}</h1>
           <div className="article-meta">
             {a.author && <span className="author">{a.author}</span>}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -190,6 +190,7 @@
     "episodePlay": "Play episode",
     "episodePlaying": "Now playing",
     "readMinutes": "{{count}} min read",
+    "viewAllFromFeed": "View all articles from this feed",
     "extractingFullText": "Extracting full text…",
     "noContent": "No content available.",
     "aiSummaryTitle": "AI summary",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -190,6 +190,7 @@
     "episodePlay": "エピソードを再生",
     "episodePlaying": "再生中",
     "readMinutes": "{{count}} 分で読了",
+    "viewAllFromFeed": "このフィードの記事をすべて表示",
     "extractingFullText": "全文を抽出中…",
     "noContent": "本文がありません。",
     "aiSummaryTitle": "AI要約",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -190,6 +190,7 @@
     "episodePlay": "播放音频",
     "episodePlaying": "正在播放",
     "readMinutes": "{{count}} 分钟阅读",
+    "viewAllFromFeed": "查看该订阅源的全部文章",
     "extractingFullText": "正在提取全文…",
     "noContent": "暂无正文内容。",
     "aiSummaryTitle": "AI 摘要",

--- a/src/styles.css
+++ b/src/styles.css
@@ -772,6 +772,11 @@ button { font-family: inherit; }
   align-items: center;
   gap: 6px;
   text-decoration: none;
+  padding: 0;
+  border: none;
+  background: none;
+  font-family: inherit;
+  cursor: pointer;
 }
 .article-feed:hover { text-decoration: underline; }
 .article-title {


### PR DESCRIPTION
Closes #68.

## What
The feed name shown above each article's title is now clickable. Clicking it selects that feed (`ArticleQuery::Feed`), so the list switches to every article from that source — the in-app equivalent of "go to the subscription to see all its articles".

It mirrors the existing tag-pill navigation in the reader, so the interaction is already familiar.

## Notes
- The element changed from a `<span>` to a `<button>`; CSS keeps the same look (the underline-on-hover affordance was already there) and adds button resets + a pointer cursor.
- Tooltip added via the new `reader.viewAllFromFeed` string (en/ja/zh).

## Testing
- `tsc --noEmit` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The feed name in the article header is now clickable, opening a view of all articles from that feed.
  * Added localized text for this action in English, Japanese, and Chinese.

* **UI Improvements**
  * The feed link now shows button-style interaction while keeping the same RSS icon and title display.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->