### PR TITLE
fix(sidebar): scope-aware refresh toast and demote refresh in context menus

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -268,7 +268,13 @@ export default function App() {
     if (refreshingRef.current) return;
     refreshingRef.current = true;
     setRefreshing(true);
-    showToast(t("app.refreshing"));
+    showToast(
+      scope?.feedId != null
+        ? t("app.refreshingFeed")
+        : scope?.folderId != null
+          ? t("app.refreshingFolder")
+          : t("app.refreshing"),
+    );
     api
       .refreshFeeds(undefined, scope)
       .then((n) => {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -254,12 +254,6 @@ export default function Sidebar({
       });
     return [
       {
-        icon: "refresh",
-        label: t("sidebar.refreshFeed"),
-        onClick: () => onRefresh({ feedId: f.id }),
-      },
-      { separator: true },
-      {
         icon: "check-all",
         label: t("sidebar.markAllRead"),
         onClick: () =>
@@ -268,6 +262,12 @@ export default function Sidebar({
             t("sidebar.toastMarkedAllRead"),
           ),
       },
+      {
+        icon: "refresh",
+        label: t("sidebar.refreshFeed"),
+        onClick: () => onRefresh({ feedId: f.id }),
+      },
+      { separator: true },
       {
         icon: "settings",
         label: t("sidebar.renameMenu"),
@@ -299,12 +299,6 @@ export default function Sidebar({
 
   const folderMenu = (folder: Folder): MenuEntry[] => [
     {
-      icon: "refresh",
-      label: t("sidebar.refreshFolder"),
-      onClick: () => onRefresh({ folderId: folder.id }),
-    },
-    { separator: true },
-    {
       icon: "check-all",
       label: t("sidebar.markAllRead"),
       onClick: () =>
@@ -313,6 +307,12 @@ export default function Sidebar({
           t("sidebar.toastMarkedAllRead"),
         ),
     },
+    {
+      icon: "refresh",
+      label: t("sidebar.refreshFolder"),
+      onClick: () => onRefresh({ folderId: folder.id }),
+    },
+    { separator: true },
     {
       icon: "settings",
       label: t("sidebar.renameMenu"),

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -99,6 +99,8 @@
     "resizeSidebar": "Resize sidebar",
     "resizeList": "Resize article list",
     "refreshing": "Refreshing all feeds…",
+    "refreshingFeed": "Refreshing feed…",
+    "refreshingFolder": "Refreshing folder…",
     "foundNew": "Found {{count}} new articles",
     "upToDate": "Up to date",
     "markedRead": "Marked {{count}} articles as read",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -99,6 +99,8 @@
     "resizeSidebar": "サイドバーの幅を調整",
     "resizeList": "記事リストの幅を調整",
     "refreshing": "すべてのフィードを更新中…",
+    "refreshingFeed": "このフィードを更新中…",
+    "refreshingFolder": "このフォルダを更新中…",
     "foundNew": "新着記事 {{count}} 件",
     "upToDate": "最新です",
     "markedRead": "{{count}} 件の記事を既読にしました",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -99,6 +99,8 @@
     "resizeSidebar": "调整侧栏宽度",
     "resizeList": "调整文章列表宽度",
     "refreshing": "正在刷新所有订阅源…",
+    "refreshingFeed": "正在刷新该订阅源…",
+    "refreshingFolder": "正在刷新该文件夹…",
     "foundNew": "发现 {{count}} 篇新文章",
     "upToDate": "已是最新",
     "markedRead": "已将 {{count}} 篇标为已读",


### PR DESCRIPTION
Follow-up to #64, addressing two issues found in acceptance testing:

1. **Wrong toast** — refreshing a single feed/folder showed "Refreshing all feeds…". Added `app.refreshingFeed` / `app.refreshingFolder` strings (en/zh/ja); `doRefresh` now picks the message by scope.
2. **Menu ordering** — "Refresh feed" / "Refresh folder" sat at the very top of the context menus. "Mark all as read" is the more common action, so refresh is moved below it.

## Testing
- `tsc --noEmit` ✅
- Verified live via `tauri dev` hot reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refresh actions now show a more specific status message for feeds and folders, instead of only a generic refresh message.
  * Added localized messages for feed and folder refresh states in English, Japanese, and Chinese.

* **UI Changes**
  * Updated the sidebar context menus so refresh options are organized more consistently for feeds and folders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->