### PR TITLE
chore(release): v0.12.0-beta.1

### DIFF
--- a/.github/workflows/update-tap.yml
+++ b/.github/workflows/update-tap.yml
@@ -18,6 +18,9 @@ on:
 jobs:
   update-tap:
     runs-on: ubuntu-latest
+    # Never bump the stable tap from a pre-release. A manual workflow_dispatch
+    # has no release payload (prerelease is null), so it still runs.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false }}
     steps:
       - name: Resolve tag / version
         id: v

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,7 +3400,7 @@ dependencies = [
 
 [[package]]
 name = "papr"
-version = "0.11.0"
+version = "0.12.0-beta.1"
 dependencies = [
  "ammonia",
  "anyhow",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "papr-cli"
-version = "0.11.0"
+version = "0.12.0-beta.1"
 dependencies = [
  "chrono",
  "clap",
@@ -3455,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "papr-core"
-version = "0.11.0"
+version = "0.12.0-beta.1"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/crates/papr-cli/Cargo.toml
+++ b/crates/papr-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "papr-cli"
-version = "0.11.0"
+version = "0.12.0-beta.1"
 edition = "2021"
 description = "papr — an agent-facing CLI over your Papr RSS feeds: read, search, triage and refresh from the shell."
 

--- a/crates/papr-core/Cargo.toml
+++ b/crates/papr-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "papr-core"
-version = "0.11.0"
+version = "0.12.0-beta.1"
 edition = "2021"
 description = "Papr's UI-free core: SQLite data layer, feed ingestion, and content sanitization. Shared by the desktop app and the agent CLI."
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "papr",
   "private": true,
-  "version": "0.11.0",
+  "version": "0.12.0-beta.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "papr"
-version = "0.11.0"
+version = "0.12.0-beta.1"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "papr"
-version = "0.11.0"
+version = "0.12.0-beta.1"
 description = "Papr — a modern RSS reader"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Papr",
-  "version": "0.11.0",
+  "version": "0.12.0-beta.1",
   "identifier": "com.thomas.papr",
   "mainBinaryName": "papr-desktop",
   "build": {


### PR DESCRIPTION
Cuts the **v0.12.0-beta.1** pre-release — the first release to ship the signed `papr` CLI artifacts + Homebrew formula landed in #79.

## Changes
- Bump all workspace crates (`papr`, `papr-cli`, `papr-core`), `tauri.conf.json` and `package.json` to `0.12.0-beta.1`; both lockfiles re-synced (member version entries only).
- **Guard `update-tap.yml` against pre-releases**: the job now skips when `github.event.release.prerelease == true`, so a beta never bumps the stable Homebrew tap. A manual `workflow_dispatch` still runs.

## Release plan (after merge)
1. Tag `v0.12.0-beta.1` on `main` → `release.yml` builds desktop bundles + the CLI (signed/notarized) into a **draft** release.
2. Publish the draft as a **pre-release**.

## Notes
- The in-app updater pulls from `releases/latest/...`, which GitHub never points at a pre-release — so stable users won't be auto-updated to the beta.
- macOS/Linux artifacts carry the full `0.12.0-beta.1` in their names; the Windows MSI's `ProductVersion` is numeric-only, so the bundler maps it to `0.12.0` (pre-release tag dropped). `fail-fast: false` keeps the other platforms + CLI shipping even if the Windows leg hiccups.