### PR TITLE
fix: sync all three panes when opening an article from search (#74, #75)

### DIFF
--- a/crates/papr-core/src/db.rs
+++ b/crates/papr-core/src/db.rs
@@ -1078,15 +1078,12 @@ pub fn upsert_article(
 }
 
 /// Build and run the article-list query for the given sidebar selection.
-pub fn list_articles(
-    conn: &Connection,
-    query: &ArticleQuery,
-    unread_only: bool,
-    search: Option<&str>,
-    oldest_first: bool,
-    limit: i64,
-    offset: i64,
-) -> AppResult<Vec<ArticleSummary>> {
+/// WHERE clauses + bind values selecting the articles for `query` under the
+/// unread filter — shared by `list_articles` and `article_index` so the two
+/// never drift in *which* rows they consider (a drift would put a located
+/// article at an index the list doesn't agree with). The returned clauses
+/// assume the `articles a JOIN feeds f` aliases used by both callers.
+fn article_filter(query: &ArticleQuery, unread_only: bool) -> (Vec<String>, Vec<Value>) {
     let mut where_clauses: Vec<String> = vec!["1=1".into()];
     let mut binds: Vec<Value> = Vec::new();
 
@@ -1113,6 +1110,61 @@ pub fn list_articles(
     if unread_only && !matches!(query, ArticleQuery::Unread) {
         where_clauses.push("a.is_read = 0".into());
     }
+    (where_clauses, binds)
+}
+
+/// The non-search ORDER BY clause shared by `list_articles` and
+/// `article_index`. See `list_articles` for why the effective date is wrapped
+/// in `datetime(COALESCE(...))`.
+fn article_order(oldest_first: bool) -> &'static str {
+    if oldest_first {
+        "datetime(COALESCE(a.published_at, a.fetched_at)) ASC, a.id ASC"
+    } else {
+        "datetime(COALESCE(a.published_at, a.fetched_at)) DESC, a.id DESC"
+    }
+}
+
+/// 0-based position of `article_id` within the list `query` would produce under
+/// the same unread filter and sort — or `None` when the article isn't in that
+/// list (filtered out, or not in this feed/folder/tag). Lets the frontend page
+/// the virtual list up to a specific article (e.g. one opened from search that
+/// lives far below the first loaded page) and scroll it into view.
+pub fn article_index(
+    conn: &Connection,
+    query: &ArticleQuery,
+    unread_only: bool,
+    oldest_first: bool,
+    article_id: i64,
+) -> AppResult<Option<i64>> {
+    let (where_clauses, mut binds) = article_filter(query, unread_only);
+    let sql = format!(
+        "SELECT pos FROM (
+             SELECT a.id AS aid,
+                    ROW_NUMBER() OVER (ORDER BY {order}) - 1 AS pos
+             FROM articles a JOIN feeds f ON f.id = a.feed_id
+             WHERE {where_sql}
+         ) WHERE aid = ?",
+        order = article_order(oldest_first),
+        where_sql = where_clauses.join(" AND "),
+    );
+    binds.push(Value::Integer(article_id));
+    let pos = conn
+        .prepare(&sql)?
+        .query_row(params_from_iter(binds), |r| r.get::<_, i64>(0))
+        .optional()?;
+    Ok(pos)
+}
+
+pub fn list_articles(
+    conn: &Connection,
+    query: &ArticleQuery,
+    unread_only: bool,
+    search: Option<&str>,
+    oldest_first: bool,
+    limit: i64,
+    offset: i64,
+) -> AppResult<Vec<ArticleSummary>> {
+    let (mut where_clauses, mut binds) = article_filter(query, unread_only);
 
     let searching = search.map(|s| !s.trim().is_empty()).unwrap_or(false);
     let mut sql = String::from(
@@ -1138,13 +1190,13 @@ pub fn list_articles(
     // `datetime()` normalises each side to a single comparable form. Backed
     // by `idx_articles_sort`, an expression index over the same wrapped
     // expression (v12) — the planner uses it for both directions, no sort.
-    sql.push_str(if searching {
-        " ORDER BY fts.rank "
-    } else if oldest_first {
-        " ORDER BY datetime(COALESCE(a.published_at, a.fetched_at)) ASC, a.id ASC "
+    if searching {
+        sql.push_str(" ORDER BY fts.rank ");
     } else {
-        " ORDER BY datetime(COALESCE(a.published_at, a.fetched_at)) DESC, a.id DESC "
-    });
+        sql.push_str(" ORDER BY ");
+        sql.push_str(article_order(oldest_first));
+        sql.push(' ');
+    }
     sql.push_str("LIMIT ? OFFSET ?");
     binds.push(Value::Integer(limit));
     binds.push(Value::Integer(offset));

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -340,6 +340,22 @@ pub async fn list_articles(
     )
 }
 
+/// 0-based position of `article_id` in the list `query` would produce (same
+/// unread filter + sort), or `None` if it isn't in that list. The frontend uses
+/// it to page the virtual list down to an article opened from search and scroll
+/// it into view.
+#[tauri::command]
+pub async fn article_index(
+    state: State<'_, AppState>,
+    query: ArticleQuery,
+    unread_only: bool,
+    oldest_first: bool,
+    article_id: i64,
+) -> AppResult<Option<i64>> {
+    let conn = state.read().await;
+    db::article_index(&conn, &query, unread_only, oldest_first, article_id)
+}
+
 #[tauri::command]
 pub async fn get_article(state: State<'_, AppState>, id: i64) -> AppResult<ArticleDetail> {
     let conn = state.read().await;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -238,6 +238,7 @@ pub fn run() {
             commands::rename_feed,
             commands::refresh_feeds,
             commands::list_articles,
+            commands::article_index,
             commands::get_article,
             commands::mark_read,
             commands::mark_starred,
@@ -290,6 +291,7 @@ pub fn run() {
             commands::delete_highlight,
             page_view::open_page_view,
             page_view::set_page_view_bounds,
+            page_view::set_page_view_visible,
             page_view::close_page_view,
         ])
         .run(tauri::generate_context!())

--- a/src-tauri/src/page_view.rs
+++ b/src-tauri/src/page_view.rs
@@ -81,6 +81,23 @@ pub async fn set_page_view_bounds(
     Ok(())
 }
 
+/// Show or hide the open page view without tearing it down. A transient
+/// overlay (context menu, modal, AI drawer) only needs the native webview out
+/// of the way for a moment — hiding keeps the loaded page alive, so dismissing
+/// the overlay reveals it instantly instead of reloading the whole page.
+/// No-op when the view isn't open.
+#[tauri::command]
+pub async fn set_page_view_visible(app: AppHandle, visible: bool) -> Result<(), String> {
+    if let Some(view) = app.get_webview(LABEL) {
+        if visible {
+            view.show().map_err(|e| e.to_string())?;
+        } else {
+            view.hide().map_err(|e| e.to_string())?;
+        }
+    }
+    Ok(())
+}
+
 /// Tear down the page view (left web mode, switched away, reader unmounted).
 #[tauri::command]
 pub async fn close_page_view(app: AppHandle) -> Result<(), String> {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,15 +26,12 @@ import ResizeHandle from "./components/ResizeHandle";
 import Icon from "./components/Icon";
 import { PANEL_BOUNDS } from "./store";
 
-// Accent palettes — ported from the design prototype (app.jsx ACCENTS).
-const ACCENTS: Record<
-  string,
-  { accent: string; soft: string; ink: string; dAccent: string; dSoft: string; dInk: string }
-> = {
-  clay: { accent: "oklch(0.60 0.13 38)", soft: "oklch(0.94 0.04 50)", ink: "oklch(0.42 0.10 38)", dAccent: "oklch(0.74 0.13 45)", dSoft: "oklch(0.32 0.06 40)", dInk: "oklch(0.80 0.10 45)" },
-  pine: { accent: "oklch(0.50 0.10 165)", soft: "oklch(0.94 0.04 160)", ink: "oklch(0.38 0.08 165)", dAccent: "oklch(0.72 0.11 170)", dSoft: "oklch(0.30 0.05 165)", dInk: "oklch(0.80 0.08 170)" },
-  indigo: { accent: "oklch(0.52 0.14 268)", soft: "oklch(0.94 0.04 270)", ink: "oklch(0.40 0.12 268)", dAccent: "oklch(0.74 0.13 270)", dSoft: "oklch(0.30 0.06 268)", dInk: "oklch(0.82 0.10 270)" },
-  ink: { accent: "oklch(0.30 0.02 50)", soft: "oklch(0.92 0.005 50)", ink: "oklch(0.20 0.01 50)", dAccent: "oklch(0.86 0.005 50)", dSoft: "oklch(0.30 0.005 50)", dInk: "oklch(0.92 0.005 50)" },
+// The single accent — terracotta clay. "One accent, used rarely"; it is a
+// fixed brand mark, not a user preference, so it lives here rather than in
+// Settings. (Ported from the design prototype's ACCENTS.clay.)
+const ACCENT = {
+  accent: "oklch(0.60 0.13 38)", soft: "oklch(0.94 0.04 50)", ink: "oklch(0.42 0.10 38)",
+  dAccent: "oklch(0.74 0.13 45)", dSoft: "oklch(0.32 0.06 40)", dInk: "oklch(0.80 0.10 45)",
 };
 
 // Native window backing per dark-shade. The webview is made non-opaque in
@@ -56,7 +53,6 @@ export default function App() {
 
   const theme = useUi((s) => s.theme);
   const darkShade = useUi((s) => s.darkShade);
-  const accent = useUi((s) => s.accent);
   const density = useUi((s) => s.density);
   const readerFont = useUi((s) => s.readerFont);
   const readerSize = useUi((s) => s.readerSize);
@@ -97,7 +93,7 @@ export default function App() {
     root.dataset.theme = theme;
     root.dataset.darkShade = darkShade;
     root.dataset.density = density;
-    const a = ACCENTS[accent] ?? ACCENTS.clay;
+    const a = ACCENT;
     const dark = theme === "dark";
     root.style.setProperty("--accent", dark ? a.dAccent : a.accent);
     root.style.setProperty("--accent-soft", dark ? a.dSoft : a.soft);
@@ -111,7 +107,7 @@ export default function App() {
     const backing = dark ? DARK_BACKING[darkShade] : "#FBF9F3";
     getCurrentWindow().setBackgroundColor(backing).catch(() => {});
     getCurrentWebview().setBackgroundColor(backing).catch(() => {});
-  }, [theme, darkShade, accent, density]);
+  }, [theme, darkShade, density]);
 
   // ── dismiss the boot splash once the app shell has mounted ──
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,6 @@ import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import * as api from "./api";
 import { useUi, READER_FONTS } from "./store";
-import type { DarkShade } from "./store";
 import { useArticleActions } from "./hooks/articleActions";
 import { readCurrentItems } from "./lib/currentList";
 import { checkForUpdates } from "./lib/updater";
@@ -34,25 +33,19 @@ const ACCENT = {
   dAccent: "oklch(0.74 0.13 45)", dSoft: "oklch(0.32 0.06 40)", dInk: "oklch(0.80 0.10 45)",
 };
 
-// Native window backing per dark-shade. The webview is made non-opaque in
+// Native window backing for the dark theme. The webview is made non-opaque in
 // lib.rs (to kill the white resize flash), so a resize exposes THIS colour in
-// the strip the webview hasn't repainted yet. Use each shade's `--reader`
-// (the widest pane, 1fr, and the right/bottom edge a resize is dragged from)
-// rather than the darker `--paper` floor — otherwise the exposed strip flashes
-// a shade darker than the reader content it sits next to. Mirrors `--reader`
-// in styles.css.
-const DARK_BACKING: Record<DarkShade, string> = {
-  default: "#25201F",
-  dimmer: "#1C1715",
-  black: "#15100F",
-};
+// the strip the webview hasn't repainted yet. Use `--reader` (the widest pane,
+// 1fr, and the right/bottom edge a resize is dragged from) rather than the
+// darker `--paper` floor — otherwise the exposed strip flashes a shade darker
+// than the reader content it sits next to. Mirrors `--reader` in styles.css.
+const DARK_BACKING = "#1D1E1F";
 
 export default function App() {
   const { t } = useTranslation();
   const qc = useQueryClient();
 
   const theme = useUi((s) => s.theme);
-  const darkShade = useUi((s) => s.darkShade);
   const density = useUi((s) => s.density);
   const readerFont = useUi((s) => s.readerFont);
   const readerSize = useUi((s) => s.readerSize);
@@ -91,7 +84,6 @@ export default function App() {
   useEffect(() => {
     const root = document.documentElement;
     root.dataset.theme = theme;
-    root.dataset.darkShade = darkShade;
     root.dataset.density = density;
     const a = ACCENT;
     const dark = theme === "dark";
@@ -104,10 +96,10 @@ export default function App() {
     // that strip blends with the reader pane it sits next to. (On Win/Linux the
     // webview is opaque, so setBackgroundColor here mainly covers their own
     // resize/overscroll; harmless on macOS where it's the NSWindow colour.)
-    const backing = dark ? DARK_BACKING[darkShade] : "#FBF9F3";
+    const backing = dark ? DARK_BACKING : "#FBF9F3";
     getCurrentWindow().setBackgroundColor(backing).catch(() => {});
     getCurrentWebview().setBackgroundColor(backing).catch(() => {});
-  }, [theme, darkShade, density]);
+  }, [theme, density]);
 
   // ── dismiss the boot splash once the app shell has mounted ──
   useEffect(() => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -102,6 +102,22 @@ export const listArticles = (
     offset,
   });
 
+/** 0-based position of `articleId` in the list these filters produce, or null
+ *  when it isn't in that list (filtered out / different feed). Drives paging the
+ *  middle pane down to an article opened from search. */
+export const articleIndex = (
+  query: ArticleQuery,
+  unreadOnly: boolean,
+  oldestFirst: boolean,
+  articleId: number,
+) =>
+  invoke<number | null>("article_index", {
+    query,
+    unreadOnly,
+    oldestFirst,
+    articleId,
+  });
+
 export const getArticle = (id: number) =>
   invoke<ArticleDetail>("get_article", { id });
 export const markRead = (id: number, read: boolean) =>
@@ -315,4 +331,6 @@ export const openPageView = (url: string, b: PageViewBounds) =>
   invoke<void>("open_page_view", { url, ...b });
 export const setPageViewBounds = (b: PageViewBounds) =>
   invoke<void>("set_page_view_bounds", { ...b });
+export const setPageViewVisible = (visible: boolean) =>
+  invoke<void>("set_page_view_visible", { visible });
 export const closePageView = () => invoke<void>("close_page_view");

--- a/src/components/AddFeedDialog.tsx
+++ b/src/components/AddFeedDialog.tsx
@@ -5,6 +5,7 @@ import * as api from "../api";
 import { useArticleActions } from "../hooks/articleActions";
 import { useFocusTrap } from "../hooks/useFocusTrap";
 import { errorText } from "../lib/errors";
+import { NO_AUTOCORRECT } from "../lib/inputProps";
 import type { DiscoveryResult } from "../types";
 import Icon from "./Icon";
 
@@ -214,6 +215,7 @@ export default function AddFeedDialog({ onClose, onToast, initialUrl }: Props) {
               autoFocus
               placeholder={t("addFeed.discoverPlaceholder")}
               aria-label={t("addFeed.urlLabel")}
+              {...NO_AUTOCORRECT}
               value={url}
               onChange={(e) => setUrl(e.target.value)}
               onKeyDown={(e) => {
@@ -305,6 +307,7 @@ export default function AddFeedDialog({ onClose, onToast, initialUrl }: Props) {
               autoFocus
               placeholder={t("addFeed.nlTitlePlaceholder")}
               aria-label={t("addFeed.nlTitleLabel")}
+              {...NO_AUTOCORRECT}
               value={nlTitle}
               onChange={(e) => setNlTitle(e.target.value)}
               onKeyDown={nlKeyDown}
@@ -316,6 +319,7 @@ export default function AddFeedDialog({ onClose, onToast, initialUrl }: Props) {
                 style={{ flex: 2 }}
                 placeholder={t("addFeed.nlHostPlaceholder")}
                 aria-label={t("addFeed.nlHostLabel")}
+                {...NO_AUTOCORRECT}
                 value={nlHost}
                 onChange={(e) => setNlHost(e.target.value)}
                 onKeyDown={nlKeyDown}
@@ -326,6 +330,7 @@ export default function AddFeedDialog({ onClose, onToast, initialUrl }: Props) {
                 style={{ flex: 1 }}
                 placeholder="993"
                 aria-label={t("addFeed.nlPortLabel")}
+                {...NO_AUTOCORRECT}
                 value={nlPort}
                 onChange={(e) => setNlPort(e.target.value)}
                 onKeyDown={nlKeyDown}
@@ -336,6 +341,7 @@ export default function AddFeedDialog({ onClose, onToast, initialUrl }: Props) {
               type="text"
               placeholder={t("addFeed.nlUserPlaceholder")}
               aria-label={t("addFeed.nlUserLabel")}
+              {...NO_AUTOCORRECT}
               value={nlUser}
               onChange={(e) => setNlUser(e.target.value)}
               onKeyDown={nlKeyDown}
@@ -345,6 +351,7 @@ export default function AddFeedDialog({ onClose, onToast, initialUrl }: Props) {
               type="password"
               placeholder={t("addFeed.nlPassPlaceholder")}
               aria-label={t("addFeed.nlPassLabel")}
+              {...NO_AUTOCORRECT}
               value={nlPass}
               onChange={(e) => setNlPass(e.target.value)}
               onKeyDown={nlKeyDown}
@@ -354,6 +361,7 @@ export default function AddFeedDialog({ onClose, onToast, initialUrl }: Props) {
               type="text"
               placeholder="INBOX"
               aria-label={t("addFeed.nlFolderLabel")}
+              {...NO_AUTOCORRECT}
               value={nlFolder}
               onChange={(e) => setNlFolder(e.target.value)}
               onKeyDown={nlKeyDown}

--- a/src/components/ArticleList.tsx
+++ b/src/components/ArticleList.tsx
@@ -1,6 +1,6 @@
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import * as api from "../api";
@@ -35,6 +35,7 @@ export default function ArticleList({ onToast }: Props) {
   const toggleUnreadOnly = useUi((s) => s.toggleUnreadOnly);
   const sortOldest = useUi((s) => s.sortOldest);
   const toggleSort = useUi((s) => s.toggleSort);
+  const listAnchor = useUi((s) => s.listAnchor);
   const viewMode = useUi((s) => s.viewMode);
   const density = useUi((s) => s.density);
   const showCardThumbs = useUi((s) => s.prefs.showCardThumbs);
@@ -56,19 +57,30 @@ export default function ArticleList({ onToast }: Props) {
   const [hover, setHover] = useState<Hover | null>(null);
   const hoverTimer = useRef<number | undefined>(undefined);
 
+  // Offset-anchored, *bidirectional* paging. `pageParam` is the row offset of a
+  // page, so any page can be the starting one (`initialPageParam: listAnchor`).
+  // Opening a deep article from search anchors here so the list loads only that
+  // article's page; the user can then page newer (up) or older (down) from it.
   const browse = useInfiniteQuery({
-    queryKey: ["articles", query, unreadOnly, sortOldest],
-    initialPageParam: 0,
+    queryKey: ["articles", query, unreadOnly, sortOldest, listAnchor],
+    initialPageParam: listAnchor,
     queryFn: ({ pageParam }) =>
       api.listArticles(query, unreadOnly, null, sortOldest, PAGE, pageParam as number),
-    getNextPageParam: (last, all) =>
-      last.length < PAGE ? undefined : all.length * PAGE,
+    getNextPageParam: (last, _all, lastParam) =>
+      last.length < PAGE ? undefined : (lastParam as number) + PAGE,
+    getPreviousPageParam: (_first, _all, firstParam) =>
+      (firstParam as number) > 0 ? Math.max(0, (firstParam as number) - PAGE) : undefined,
   });
 
   const items: ArticleSummary[] = useMemo(
     () => browse.data?.pages.flat() ?? [],
     [browse.data],
   );
+  // Global row offset of `items[0]` — the param of the earliest loaded page
+  // (which can sit below the anchor once the user pages upward). Global index
+  // of `items[k]` is `baseOffset + k`, the bridge between the virtual list's
+  // local indices and the backend's absolute positions (`article_index`).
+  const baseOffset = (browse.data?.pageParams?.[0] as number | undefined) ?? listAnchor;
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const rowEstimate =
@@ -102,13 +114,149 @@ export default function ArticleList({ onToast }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [virt.range?.endIndex, items.length, browse.hasNextPage, browse.isFetchingNextPage]);
 
-  // Keep the keyboard-selected article visible.
+  // Load the previous (newer) page as the top approaches — only ever non-empty
+  // when the list is anchored mid-feed (an article opened from search), so a
+  // normal newest-first browse never triggers it.
+  useEffect(() => {
+    const first = virt.getVirtualItems()[0];
+    if (
+      first &&
+      first.index <= 5 &&
+      browse.hasPreviousPage &&
+      !browse.isFetchingPreviousPage
+    ) {
+      browse.fetchPreviousPage();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [virt.range?.startIndex, browse.hasPreviousPage, browse.isFetchingPreviousPage]);
+
+  // Prepending a newer page shifts every loaded row down by a page, so the
+  // viewport would jump. Before paint, nudge the scroll position down by the
+  // newly prepended rows' height to keep the article under the user's eyes put.
+  // Estimate-based (exact for the uniform list rows; a hair off for cards).
+  // Guarded by the list signature so a *new* list (feed switch, filter, anchor
+  // jump) — which also moves `baseOffset` — isn't mistaken for a prepend.
+  const prevBaseRef = useRef(baseOffset);
+  const listSigRef = useRef("");
+  useLayoutEffect(() => {
+    const sig = `${JSON.stringify(query)}|${unreadOnly}|${sortOldest}|${listAnchor}`;
+    const prev = prevBaseRef.current;
+    prevBaseRef.current = baseOffset;
+    if (sig !== listSigRef.current) {
+      listSigRef.current = sig;
+      return; // new list context — not a prepend, don't touch the scroll
+    }
+    if (baseOffset < prev) {
+      const el = scrollRef.current;
+      if (el) el.scrollTop += (prev - baseOffset) * rowEstimate;
+    }
+  }, [baseOffset, query, unreadOnly, sortOldest, listAnchor, rowEstimate]);
+
+  // The article we're keeping centred. A one-shot scroll lands on *estimated*
+  // row heights when the list hasn't measured yet — fatal for long rows (an
+  // article-as-a-site page), which settle far from their estimate, leaving the
+  // target off-screen. So instead of scrolling once and locking, we hold the
+  // article centred and re-centre every time the total size shifts (rows
+  // measuring, images loading) until it stops moving.
+  const [reveal, setReveal] = useState<number | null>(null);
+  const totalSize = virt.getTotalSize();
+  useEffect(() => {
+    if (reveal == null) return;
+    const i = items.findIndex((a) => a.id === reveal);
+    if (i < 0) return; // not loaded into the window yet — wait
+    virt.scrollToIndex(i, { align: "center" });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reveal, items, totalSize]);
+
+  // Hand control back the instant the user drives the list themselves, so we
+  // never fight their scroll while a long page is still settling. A safety
+  // deadline releases too, in case the size never stops changing.
+  useEffect(() => {
+    if (reveal == null) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    const release = () => setReveal(null);
+    el.addEventListener("wheel", release, { passive: true });
+    el.addEventListener("pointerdown", release, { passive: true });
+    el.addEventListener("keydown", release);
+    const timer = window.setTimeout(release, 3000);
+    return () => {
+      el.removeEventListener("wheel", release);
+      el.removeEventListener("pointerdown", release);
+      el.removeEventListener("keydown", release);
+      window.clearTimeout(timer);
+    };
+  }, [reveal]);
+
+  // Reveal the selected article. The common case (keyboard nav, clicking a row)
+  // finds it already loaded and just scrolls. The hard case is an article
+  // opened from search: selecting it also switches feed, and it may live far
+  // below the first loaded page — or be hidden by the "unread only" filter. We
+  // ask the backend for its position under the current filters and page the
+  // virtual list down to it (see the locate effect below); if it's filtered out
+  // (null), drop the unread filter so it rejoins the list and locate again.
+  const revealedForRef = useRef<number | null>(null);
+  const lookupRef = useRef<number | null>(null);
+  const [locate, setLocate] = useState<{ id: number; rank: number } | null>(null);
   useEffect(() => {
     if (selectedId == null) return;
+    if (revealedForRef.current === selectedId) return;
     const i = items.findIndex((a) => a.id === selectedId);
-    if (i >= 0) virt.scrollToIndex(i, { align: "auto" });
+    if (i >= 0) {
+      revealedForRef.current = selectedId;
+      setLocate(null);
+      setReveal(selectedId);
+      return;
+    }
+    // Not in the loaded window. Locate read-agnostically: an "unread only" view
+    // can't reliably hold the article we're opening (it may already be read, or
+    // get marked read on open, and then the page query filters it right back
+    // out), so switch to "all" first, then page to it. Only reached for an
+    // article below the loaded window — a recent one is already in view.
+    if (lookupRef.current === selectedId) return;
+    if (unreadOnly) {
+      toggleUnreadOnly();
+      return;
+    }
+    lookupRef.current = selectedId;
+    const target = selectedId;
+    api
+      .articleIndex(query, false, sortOldest, target)
+      .then((rank) => {
+        if (useUi.getState().selectedArticleId !== target) return;
+        if (rank != null) setLocate({ id: target, rank });
+      })
+      .catch(() => {});
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedId]);
+  }, [selectedId, items]);
+
+  // Drive the located article into view. If it's outside the loaded window,
+  // jump the paging anchor to its page so the list reloads *only* there (rather
+  // than every page above it); once that page is in, Effect above scrolls to it.
+  useEffect(() => {
+    if (!locate) return;
+    if (locate.id !== selectedId) {
+      setLocate(null);
+      return;
+    }
+    const local = locate.rank - baseOffset;
+    if (local >= 0 && local < items.length) {
+      revealedForRef.current = locate.id;
+      setReveal(locate.id);
+      setLocate(null);
+      return;
+    }
+    const targetAnchor = Math.floor(locate.rank / PAGE) * PAGE;
+    if (listAnchor !== targetAnchor) useUi.getState().setListAnchor(targetAnchor);
+    // else: anchor already at the target page, still loading — wait for `items`.
+  }, [locate, selectedId, items, baseOffset, listAnchor]);
+
+  // A new query or filter rebuilds the list, so any in-flight locate is stale —
+  // clear it and allow a fresh lookup under the new filters.
+  useEffect(() => {
+    lookupRef.current = null;
+    setLocate(null);
+  }, [query, unreadOnly, sortOldest]);
 
   useEffect(() => () => window.clearTimeout(hoverTimer.current), []);
 
@@ -127,9 +275,11 @@ export default function ArticleList({ onToast }: Props) {
   // a new feed/folder/tag opens scrolled to wherever the *previous* list was
   // left — burying its newest articles below the fold. `scrollToOffset(0)`
   // also resets the virtualizer's internal offset, keeping its rendered window
-  // in sync with the DOM scroll position.
+  // in sync with the DOM scroll position. Skipped when the query change came
+  // from opening a specific article (search → feed + article in one step), so
+  // the selected-article scroll above isn't overridden back to the top.
   useEffect(() => {
-    virt.scrollToOffset(0);
+    if (selectedId == null) virt.scrollToOffset(0);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query]);
 

--- a/src/components/ArticleList.tsx
+++ b/src/components/ArticleList.tsx
@@ -152,19 +152,21 @@ export default function ArticleList({ onToast }: Props) {
     }
   }, [baseOffset, query, unreadOnly, sortOldest, listAnchor, rowEstimate]);
 
-  // The article we're keeping centred. A one-shot scroll lands on *estimated*
+  // The article we're keeping in view. A one-shot scroll lands on *estimated*
   // row heights when the list hasn't measured yet — fatal for long rows (an
   // article-as-a-site page), which settle far from their estimate, leaving the
-  // target off-screen. So instead of scrolling once and locking, we hold the
-  // article centred and re-centre every time the total size shifts (rows
-  // measuring, images loading) until it stops moving.
+  // target off-screen. So instead of scrolling once and locking, we keep the
+  // article in view, re-checking every time the total size shifts (rows
+  // measuring, images loading) until it stops moving. `align: "auto"` only
+  // scrolls when the row isn't already fully visible, so *clicking* a visible
+  // row never jolts the list — it just opens.
   const [reveal, setReveal] = useState<number | null>(null);
   const totalSize = virt.getTotalSize();
   useEffect(() => {
     if (reveal == null) return;
     const i = items.findIndex((a) => a.id === reveal);
     if (i < 0) return; // not loaded into the window yet — wait
-    virt.scrollToIndex(i, { align: "center" });
+    virt.scrollToIndex(i, { align: "auto" });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [reveal, items, totalSize]);
 

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -5,6 +5,7 @@ import * as api from "../api";
 import { useUi } from "../store";
 import { feedHost, relTime } from "../lib/feedMeta";
 import { modCombo } from "../lib/platform";
+import { NO_AUTOCORRECT } from "../lib/inputProps";
 import type { ArticleSummary, Feed } from "../types";
 import Icon, { type IconName } from "./Icon";
 import FeedAvatar from "./FeedAvatar";
@@ -271,6 +272,7 @@ export default function CommandPalette({
             onKeyDown={handleKey}
             placeholder={t("commandPalette.searchPlaceholder")}
             aria-label={t("commandPalette.searchPlaceholder")}
+            {...NO_AUTOCORRECT}
             role="combobox"
             aria-expanded={items.length > 0}
             aria-controls="cp-listbox"

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -1,8 +1,9 @@
-import { useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import Icon, { type IconName } from "./Icon";
 import { clampToViewport } from "../lib/viewport";
 import { useDismiss } from "../hooks/useDismiss";
 import { useMenuKeyboard } from "../hooks/useMenuKeyboard";
+import { useUi } from "../store";
 
 export type MenuEntry =
   | {
@@ -43,6 +44,16 @@ export default function ContextMenu({ x, y, items, onClose }: Props) {
   }, [x, y]);
 
   useDismiss(ref, onClose);
+
+  // Flag a menu as open for the whole app. The reader's native original-page
+  // webview floats above the DOM, so it must suspend while a menu is up or it
+  // covers the menu's right edge (issue #74). One signal here covers every
+  // context menu, since they all render through this component.
+  useEffect(() => {
+    const setMenuOpen = useUi.getState().setMenuOpen;
+    setMenuOpen(true);
+    return () => setMenuOpen(false);
+  }, []);
 
   // Focus management on open/close plus Arrow/Home/End/Enter navigation,
   // shared with the other role="menu" popovers.

--- a/src/components/ExploreDialog.tsx
+++ b/src/components/ExploreDialog.tsx
@@ -5,6 +5,7 @@ import * as api from "../api";
 import { useArticleActions } from "../hooks/articleActions";
 import { useFocusTrap } from "../hooks/useFocusTrap";
 import { reportError } from "../toast";
+import { NO_AUTOCORRECT } from "../lib/inputProps";
 import FeedAvatar from "./FeedAvatar";
 import Icon from "./Icon";
 
@@ -151,6 +152,7 @@ export default function ExploreDialog({ onClose, onToast }: Props) {
               aria-label={t("explore.searchLabel")}
               value={search}
               onChange={(e) => setSearch(e.target.value)}
+              {...NO_AUTOCORRECT}
             />
           </div>
           <div

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -1,6 +1,8 @@
-// Minimal stroke icon set — ported 1:1 from the design prototype (icons.jsx).
+// Rounded stroke icon set — redesigned on a consistent 24×24 grid for a
+// smoother, more modern, editorial feel. Geometry follows the Lucide
+// convention (round caps/joins, generous corner radii, optically balanced).
 
-const STROKE = 1.6;
+const STROKE = 1.75;
 
 export type IconName =
   | "inbox" | "circle" | "unread" | "star" | "star-fill" | "bookmark"
@@ -50,101 +52,101 @@ export default function Icon({
 
   switch (name) {
     case "inbox":
-      return <svg {...p}><path d="M3 12l3-7h12l3 7M3 12v6a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-6M3 12h5l2 3h4l2-3h5" /></svg>;
+      return <svg {...p}><path d="M22 12h-5l-2 3h-6l-2-3H2" /><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z" /></svg>;
     case "circle":
-      return <svg {...p}><circle cx="12" cy="12" r="8" /></svg>;
+      return <svg {...p}><circle cx="12" cy="12" r="9" /></svg>;
     case "unread":
-      return <svg {...p}><circle cx="12" cy="12" r="8" /><circle cx="12" cy="12" r="3.2" fill={color} stroke="none" /></svg>;
+      return <svg {...p}><circle cx="12" cy="12" r="9" /><circle cx="12" cy="12" r="3.4" fill={color} stroke="none" /></svg>;
     case "star":
-      return <svg {...p}><path d="M12 3.5l2.7 5.4 6 .9-4.3 4.2 1 6-5.4-2.8L6.6 20l1-6L3.3 9.8l6-.9z" /></svg>;
+      return <svg {...p}><path d="M11.27 3.16a.82.82 0 0 1 1.46 0l2.3 4.66a.82.82 0 0 0 .62.45l5.14.75a.82.82 0 0 1 .45 1.4l-3.72 3.62a.82.82 0 0 0-.24.73l.88 5.12a.82.82 0 0 1-1.19.86l-4.6-2.42a.82.82 0 0 0-.76 0l-4.6 2.42a.82.82 0 0 1-1.19-.86l.88-5.12a.82.82 0 0 0-.24-.73L2.7 10.42a.82.82 0 0 1 .45-1.4l5.14-.75a.82.82 0 0 0 .62-.45z" /></svg>;
     case "star-fill":
-      return <svg {...filled}><path d="M12 3.5l2.7 5.4 6 .9-4.3 4.2 1 6-5.4-2.8L6.6 20l1-6L3.3 9.8l6-.9z" /></svg>;
+      return <svg {...filled}><path d="M11.27 3.16a.82.82 0 0 1 1.46 0l2.3 4.66a.82.82 0 0 0 .62.45l5.14.75a.82.82 0 0 1 .45 1.4l-3.72 3.62a.82.82 0 0 0-.24.73l.88 5.12a.82.82 0 0 1-1.19.86l-4.6-2.42a.82.82 0 0 0-.76 0l-4.6 2.42a.82.82 0 0 1-1.19-.86l.88-5.12a.82.82 0 0 0-.24-.73L2.7 10.42a.82.82 0 0 1 .45-1.4l5.14-.75a.82.82 0 0 0 .62-.45z" /></svg>;
     case "bookmark":
-      return <svg {...p}><path d="M6 4h12v17l-6-3.5L6 21z" /></svg>;
+      return <svg {...p}><path d="M18 21l-6-4.2L6 21V6a3 3 0 0 1 3-3h6a3 3 0 0 1 3 3z" /></svg>;
     case "bookmark-fill":
-      return <svg {...filled}><path d="M6 4h12v17l-6-3.5L6 21z" /></svg>;
+      return <svg {...filled}><path d="M18 21l-6-4.2L6 21V6a3 3 0 0 1 3-3h6a3 3 0 0 1 3 3z" /></svg>;
     case "clock":
-      return <svg {...p}><circle cx="12" cy="12" r="8" /><path d="M12 7.5V12l3 2" /></svg>;
+      return <svg {...p}><circle cx="12" cy="12" r="9" /><path d="M12 7v5l3.5 2" /></svg>;
     case "tag":
-      return <svg {...p}><path d="M3 12V4h8l10 10-8 8-10-10z" /><circle cx="7.5" cy="7.5" r="1.2" fill={color} stroke="none" /></svg>;
+      return <svg {...p}><path d="M12.59 2.59A2 2 0 0 0 11.17 2H5a3 3 0 0 0-3 3v6.17a2 2 0 0 0 .59 1.42l8.3 8.3a2.4 2.4 0 0 0 3.4 0l6.4-6.4a2.4 2.4 0 0 0 0-3.4z" /><circle cx="7.5" cy="7.5" r="1.1" fill={color} stroke="none" /></svg>;
     case "folder":
-      return <svg {...p}><path d="M3 6a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" /></svg>;
+      return <svg {...p}><path d="M20 20a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-7.5a2 2 0 0 1-1.6-.8l-1-1.4A2 2 0 0 0 8.3 4H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2z" /></svg>;
     case "rss":
-      return <svg {...p}><path d="M4 11a9 9 0 0 1 9 9M4 4a16 16 0 0 1 16 16" /><circle cx="5" cy="19" r="1.5" fill={color} stroke="none" /></svg>;
+      return <svg {...p}><path d="M4 11a9 9 0 0 1 9 9M4 4a16 16 0 0 1 16 16" /><circle cx="5" cy="19" r="1.4" fill={color} stroke="none" /></svg>;
     case "search":
-      return <svg {...p}><circle cx="11" cy="11" r="7" /><path d="M16 16l4 4" /></svg>;
+      return <svg {...p}><circle cx="11" cy="11" r="7.5" /><path d="m20 20-4.3-4.3" /></svg>;
     case "plus":
       return <svg {...p}><path d="M12 5v14M5 12h14" /></svg>;
     case "check":
-      return <svg {...p}><path d="M4 12l5 5L20 6" /></svg>;
+      return <svg {...p}><path d="M20 6 9 17l-5-5" /></svg>;
     case "check-all":
-      return <svg {...p}><path d="M3 12l4 4 8-8M11 16l5 5L24 11" /></svg>;
+      return <svg {...p}><path d="M18 6 7 17l-5-5M22 10l-7.5 7.5L13 16" /></svg>;
     case "sort":
-      return <svg {...p}><path d="M7 4v16M4 7l3-3 3 3M17 20V4M14 17l3 3 3-3" /></svg>;
+      return <svg {...p}><path d="M7 4v16M3.5 7.5 7 4l3.5 3.5M17 20V4M13.5 16.5 17 20l3.5-3.5" /></svg>;
     case "sparkle":
-      return <svg {...p}><path d="M12 4l1.7 4.3L18 10l-4.3 1.7L12 16l-1.7-4.3L6 10l4.3-1.7zM19 4.5l.7 1.8L21.5 7l-1.8.7L19 9.5l-.7-1.8L16.5 7l1.8-.7zM6 16l.7 1.8L8.5 18.5l-1.8.7L6 21l-.7-1.8L3.5 18.5l1.8-.7z" /></svg>;
+      return <svg {...p}><path d="M11.4 2.6a.65.65 0 0 1 1.2 0l1.55 4.13a2 2 0 0 0 1.17 1.17l4.13 1.55a.65.65 0 0 1 0 1.2l-4.13 1.55a2 2 0 0 0-1.17 1.17l-1.55 4.13a.65.65 0 0 1-1.2 0l-1.55-4.13a2 2 0 0 0-1.17-1.17L4.55 11.6a.65.65 0 0 1 0-1.2l4.13-1.55a2 2 0 0 0 1.17-1.17z" /><path d="M19 14v3M20.5 15.5h-3M5 4v3M6.5 5.5h-3" /></svg>;
     case "sparkle-fill":
-      return <svg {...filled}><path d="M12 4l1.7 4.3L18 10l-4.3 1.7L12 16l-1.7-4.3L6 10l4.3-1.7zM19 4.5l.7 1.8L21.5 7l-1.8.7L19 9.5l-.7-1.8L16.5 7l1.8-.7zM6 16l.7 1.8L8.5 18.5l-1.8.7L6 21l-.7-1.8L3.5 18.5l1.8-.7z" /></svg>;
+      return <svg {...p}><path d="M11.4 2.6a.65.65 0 0 1 1.2 0l1.55 4.13a2 2 0 0 0 1.17 1.17l4.13 1.55a.65.65 0 0 1 0 1.2l-4.13 1.55a2 2 0 0 0-1.17 1.17l-1.55 4.13a.65.65 0 0 1-1.2 0l-1.55-4.13a2 2 0 0 0-1.17-1.17L4.55 11.6a.65.65 0 0 1 0-1.2l4.13-1.55a2 2 0 0 0 1.17-1.17z" fill={color} stroke="none" /><path d="M19 14v3M20.5 15.5h-3M5 4v3M6.5 5.5h-3" /></svg>;
     case "open":
-      return <svg {...p}><path d="M14 4h6v6M20 4l-8 8M19 13v5a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h5" /></svg>;
+      return <svg {...p}><path d="M15 3h6v6M21 3l-9 9M18 13v5a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3V9a3 3 0 0 1 3-3h5" /></svg>;
     case "share":
-      return <svg {...p}><path d="M12 4v12M12 4l-4 4M12 4l4 4M5 14v4a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-4" /></svg>;
+      return <svg {...p}><path d="M12 15V3M8.5 6.5 12 3l3.5 3.5M5 13v5a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-5" /></svg>;
     case "send":
-      return <svg {...p}><path d="M21 3L10 14M21 3l-7 18-4-8-8-4z" /></svg>;
+      return <svg {...p}><path d="M21.5 2.5 10.5 13.5M21.5 2.5l-7 19-4-8.5-8.5-4z" /></svg>;
     case "more":
-      return <svg {...p}><circle cx="5" cy="12" r="1.2" fill={color} stroke="none" /><circle cx="12" cy="12" r="1.2" fill={color} stroke="none" /><circle cx="19" cy="12" r="1.2" fill={color} stroke="none" /></svg>;
+      return <svg {...p}><circle cx="5" cy="12" r="1.3" fill={color} stroke="none" /><circle cx="12" cy="12" r="1.3" fill={color} stroke="none" /><circle cx="19" cy="12" r="1.3" fill={color} stroke="none" /></svg>;
     case "refresh":
-      return <svg {...p}><path d="M20 8a8 8 0 0 0-14 0M20 4v4h-4M4 16a8 8 0 0 0 14 0M4 20v-4h4" /></svg>;
+      return <svg {...p}><path d="M3 12a9 9 0 0 1 15.3-6.4L21 8M21 3v5h-5M21 12a9 9 0 0 1-15.3 6.4L3 16M3 21v-5h5" /></svg>;
     case "settings":
-      return <svg {...p}><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" /></svg>;
+      return <svg {...p}><circle cx="12" cy="12" r="3" /><path d="M12.2 2h-.4a2 2 0 0 0-2 2v.2a2 2 0 0 1-1 1.7l-.4.3a2 2 0 0 1-2 0l-.2-.1a2 2 0 0 0-2.7.7l-.2.4a2 2 0 0 0 .7 2.7l.2.1a2 2 0 0 1 1 1.7v.5a2 2 0 0 1-1 1.7l-.2.1a2 2 0 0 0-.7 2.7l.2.4a2 2 0 0 0 2.7.7l.2-.1a2 2 0 0 1 2 0l.4.3a2 2 0 0 1 1 1.7V20a2 2 0 0 0 2 2h.4a2 2 0 0 0 2-2v-.2a2 2 0 0 1 1-1.7l.4-.3a2 2 0 0 1 2 0l.2.1a2 2 0 0 0 2.7-.7l.2-.4a2 2 0 0 0-.7-2.7l-.2-.1a2 2 0 0 1-1-1.7v-.5a2 2 0 0 1 1-1.7l.2-.1a2 2 0 0 0 .7-2.7l-.2-.4a2 2 0 0 0-2.7-.7l-.2.1a2 2 0 0 1-2 0l-.4-.3a2 2 0 0 1-1-1.7V4a2 2 0 0 0-2-2z" /></svg>;
     case "chevron-down":
-      return <svg {...p}><path d="M6 9l6 6 6-6" /></svg>;
+      return <svg {...p}><path d="m6 9 6 6 6-6" /></svg>;
     case "chevron-right":
-      return <svg {...p}><path d="M9 6l6 6-6 6" /></svg>;
+      return <svg {...p}><path d="m9 18 6-6-6-6" /></svg>;
     case "globe":
-      return <svg {...p}><circle cx="12" cy="12" r="9" /><path d="M3 12h18M12 3a14 14 0 0 1 0 18M12 3a14 14 0 0 0 0 18" /></svg>;
+      return <svg {...p}><circle cx="12" cy="12" r="9" /><path d="M3 12h18M12 3a13 13 0 0 1 0 18M12 3a13 13 0 0 0 0 18" /></svg>;
     case "focus":
-      return <svg {...p}><path d="M4 9V5h4M20 9V5h-4M4 15v4h4M20 15v4h-4" /></svg>;
+      return <svg {...p}><path d="M4 8V6a2 2 0 0 1 2-2h2M16 4h2a2 2 0 0 1 2 2v2M20 16v2a2 2 0 0 1-2 2h-2M8 20H6a2 2 0 0 1-2-2v-2" /></svg>;
     case "arrow-down":
-      return <svg {...p}><path d="M12 5v14M5 12l7 7 7-7" /></svg>;
+      return <svg {...p}><path d="M12 5v14M19 12l-7 7-7-7" /></svg>;
     case "arrow-up":
       return <svg {...p}><path d="M12 19V5M5 12l7-7 7 7" /></svg>;
     case "eye":
-      return <svg {...p}><path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7S2 12 2 12z" /><circle cx="12" cy="12" r="3" /></svg>;
+      return <svg {...p}><path d="M2.5 12a10 10 0 0 1 19 0 10 10 0 0 1-19 0z" /><circle cx="12" cy="12" r="3" /></svg>;
     case "eye-off":
-      return <svg {...p}><path d="M3 3l18 18M10.6 6.2A10.5 10.5 0 0 1 22 12s-1.4 2.6-4 4.5M6.4 7.4C3.6 9.2 2 12 2 12s3.5 7 10 7c2 0 3.7-.6 5.2-1.6M9.9 9.9a3 3 0 0 0 4.2 4.2" /></svg>;
+      return <svg {...p}><path d="M10.7 5.1A10 10 0 0 1 21.5 12a10.2 10.2 0 0 1-1.6 2.6M6.5 7.4A10 10 0 0 0 2.5 12a10 10 0 0 0 13 5.4M9.9 9.9a3 3 0 0 0 4.2 4.2" /><path d="m3 3 18 18" /></svg>;
     case "trash":
-      return <svg {...p}><path d="M4 7h16M9 7V4h6v3M6 7l1 13a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2l1-13" /></svg>;
+      return <svg {...p}><path d="M3 6h18M19 6v13a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2M10 11v5M14 11v5" /></svg>;
     case "mute":
-      return <svg {...p}><path d="M11 5L6 9H3v6h3l5 4zM16 9l4 6M20 9l-4 6" /></svg>;
+      return <svg {...p}><path d="M11 5 6 9H3a1 1 0 0 0-1 1v4a1 1 0 0 0 1 1h3l5 4z" /><path d="m16 9 5 6M21 9l-5 6" /></svg>;
     case "pin":
-      return <svg {...p}><path d="M12 2l3 6 5 1-4 4 1 6-5-3-5 3 1-6-4-4 5-1z" /></svg>;
+      return <svg {...p}><path d="M12 17v5M9 10.8a2 2 0 0 1-1.1 1.8l-1.8.9A2 2 0 0 0 5 15.2v.8a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.8a2 2 0 0 0-1.1-1.7l-1.8-.9a2 2 0 0 1-1.1-1.8V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z" /></svg>;
     case "x":
-      return <svg {...p}><path d="M6 6l12 12M18 6L6 18" /></svg>;
+      return <svg {...p}><path d="M18 6 6 18M6 6l12 12" /></svg>;
     case "command":
-      return <svg {...p}><path d="M18 6a3 3 0 1 0-3 3h3v6h-3a3 3 0 1 0 3 3v-3H9v3a3 3 0 1 0 3-3V9H9V6a3 3 0 1 0-3 3" /></svg>;
+      return <svg {...p}><path d="M15 6v12a3 3 0 1 0 3-3H6a3 3 0 1 0 3 3V6a3 3 0 1 0-3 3h12a3 3 0 1 0-3-3" /></svg>;
     case "copy":
-      return <svg {...p}><rect x="9" y="9" width="11" height="11" rx="2" /><path d="M5 15V5a2 2 0 0 1 2-2h10" /></svg>;
+      return <svg {...p}><rect x="8" y="8" width="13" height="13" rx="2.5" /><path d="M4 16a2 2 0 0 1-2-2V5a3 3 0 0 1 3-3h9a2 2 0 0 1 2 2" /></svg>;
     case "list":
-      return <svg {...p}><path d="M4 6h16M4 12h16M4 18h16" /></svg>;
+      return <svg {...p}><path d="M8 6h13M8 12h13M8 18h13" /><circle cx="3.5" cy="6" r="1.1" fill={color} stroke="none" /><circle cx="3.5" cy="12" r="1.1" fill={color} stroke="none" /><circle cx="3.5" cy="18" r="1.1" fill={color} stroke="none" /></svg>;
     case "grid":
-      return <svg {...p}><rect x="3" y="3" width="8" height="8" rx="1.5" /><rect x="13" y="3" width="8" height="8" rx="1.5" /><rect x="3" y="13" width="8" height="8" rx="1.5" /><rect x="13" y="13" width="8" height="8" rx="1.5" /></svg>;
+      return <svg {...p}><rect x="3" y="3" width="7.5" height="7.5" rx="2" /><rect x="13.5" y="3" width="7.5" height="7.5" rx="2" /><rect x="3" y="13.5" width="7.5" height="7.5" rx="2" /><rect x="13.5" y="13.5" width="7.5" height="7.5" rx="2" /></svg>;
     case "text":
-      return <svg {...p}><path d="M5 6h14M5 6V4.5M19 6V4.5M12 6v14M9 20h6" /></svg>;
+      return <svg {...p}><path d="M4 7V4h16v3M12 4v16M9 20h6" /></svg>;
     case "alert":
-      return <svg {...p}><path d="M12 4L2.5 20.5h19zM12 10v5" /><circle cx="12" cy="17.6" r="0.4" fill={color} stroke="none" /></svg>;
+      return <svg {...p}><path d="M10.3 3.9 2.4 18a2 2 0 0 0 1.7 3h15.8a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z" /><path d="M12 9v4" /><circle cx="12" cy="17" r="0.5" fill={color} stroke="none" /></svg>;
     case "play":
-      return <svg {...filled}><path d="M7 4.5v15l13-7.5z" /></svg>;
+      return <svg {...filled}><path d="M8 5.14a1 1 0 0 1 1.52-.85l10.5 6.86a1 1 0 0 1 0 1.7L9.52 19.7A1 1 0 0 1 8 18.86z" /></svg>;
     case "pause":
-      return <svg {...filled}><rect x="6" y="4.5" width="4.2" height="15" rx="1" /><rect x="13.8" y="4.5" width="4.2" height="15" rx="1" /></svg>;
+      return <svg {...filled}><rect x="6" y="5" width="4.2" height="14" rx="1.6" /><rect x="13.8" y="5" width="4.2" height="14" rx="1.6" /></svg>;
     case "skip-back":
-      return <svg {...p}><path d="M11 6a8 8 0 1 1-3 6" /><path d="M8 4v6h6" /></svg>;
+      return <svg {...p}><path d="M11 5a7 7 0 1 1-6.32 4" /><path d="M5 3.5 4.5 9 10 8.5" /></svg>;
     case "skip-fwd":
-      return <svg {...p}><path d="M13 6a8 8 0 1 0 3 6" /><path d="M16 4v6h-6" /></svg>;
+      return <svg {...p}><path d="M13 5a7 7 0 1 0 6.32 4" /><path d="M19 3.5 19.5 9 14 8.5" /></svg>;
     case "headphones":
-      return <svg {...p}><path d="M4 14v-2a8 8 0 0 1 16 0v2" /><rect x="2.5" y="13" width="4.5" height="7" rx="2" /><rect x="17" y="13" width="4.5" height="7" rx="2" /></svg>;
+      return <svg {...p}><path d="M4 14v-2a8 8 0 0 1 16 0v2" /><rect x="2.5" y="13" width="4.5" height="7" rx="2.2" /><rect x="17" y="13" width="4.5" height="7" rx="2.2" /></svg>;
     case "papr":
-      return <svg {...p}><path d="M5 3h8.5L19 8.5V21H5Z" /><path d="M13.5 3v5.5H19" /><path d="M8 13.5a3.5 3.5 0 0 1 3.5 3.5M8 11a6 6 0 0 1 6 6" /><circle cx="8" cy="17" r="1.15" fill={color} stroke="none" /></svg>;
+      return <svg {...p}><path d="M6 3h7l5 5v12a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1z" /><path d="M13 3v4a1 1 0 0 0 1 1h4" /><path d="M8 13.5a3.5 3.5 0 0 1 3.5 3.5M8 11a6 6 0 0 1 6 6" /><circle cx="8" cy="17" r="1.1" fill={color} stroke="none" /></svg>;
     default:
       return null;
   }

--- a/src/components/PromptDialog.tsx
+++ b/src/components/PromptDialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useFocusTrap } from "../hooks/useFocusTrap";
+import { NO_AUTOCORRECT } from "../lib/inputProps";
 
 interface Props {
   title: string;
@@ -70,6 +71,7 @@ export default function PromptDialog({
           value={value}
           placeholder={placeholder}
           aria-label={placeholder ?? title}
+          {...NO_AUTOCORRECT}
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={(e) => {
             // Ignore the Enter that confirms an IME candidate (CJK input) —

--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -244,13 +244,14 @@ export default function Reader({ onToast }: Props) {
   // Anything that floats over the reading area must suspend the page view: the
   // child webview floats above the whole DOM, so it would otherwise occlude a
   // covering modal (subscribe / settings / explore — issue #54), a context
-  // menu raised over the reader (issue #74), or the AI drawer that slides over
-  // the reader's right edge. We *hide* the webview rather than tear it down, so
-  // dismissing the overlay reveals the already-loaded page instantly instead of
-  // reloading it (the bounds keep syncing while hidden, below).
+  // menu raised over the reader (issue #74), the tag picker, or the AI drawer
+  // that slides over the reader's right edge. We *hide* the webview rather than
+  // tear it down, so dismissing the overlay reveals the already-loaded page
+  // instantly instead of reloading it (the bounds keep syncing while hidden,
+  // below).
   const modalOpen = useUi((s) => s.modalOpen);
   const menuOpen = useUi((s) => s.menuOpen);
-  const overlayOpen = modalOpen || menuOpen || aiOpen;
+  const overlayOpen = modalOpen || menuOpen || aiOpen || tagPick != null;
   // Read the latest value inside the lifecycle effect without making it a
   // dependency — overlays toggle visibility (below), never the webview's life.
   const overlayOpenRef = useRef(overlayOpen);

--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -241,16 +241,27 @@ export default function Reader({ onToast }: Props) {
   // webview aligned to it across window/sidebar resizes. (Switching articles
   // resets viewMode to "reader" above, so a.url is stable within a session.)
   const articleUrl = a?.url ?? null;
-  // Anything that floats over the reading area suspends the page view: the
+  // Anything that floats over the reading area must suspend the page view: the
   // child webview floats above the whole DOM, so it would otherwise occlude a
-  // covering modal (subscribe / settings / explore — issue #54) or the AI
-  // drawer that slides over the reader's right edge. When the overlay closes
-  // this effect re-runs and re-opens the view at the current bounds.
+  // covering modal (subscribe / settings / explore — issue #54), a context
+  // menu raised over the reader (issue #74), or the AI drawer that slides over
+  // the reader's right edge. We *hide* the webview rather than tear it down, so
+  // dismissing the overlay reveals the already-loaded page instantly instead of
+  // reloading it (the bounds keep syncing while hidden, below).
   const modalOpen = useUi((s) => s.modalOpen);
-  const overlayOpen = modalOpen || aiOpen;
+  const menuOpen = useUi((s) => s.menuOpen);
+  const overlayOpen = modalOpen || menuOpen || aiOpen;
+  // Read the latest value inside the lifecycle effect without making it a
+  // dependency — overlays toggle visibility (below), never the webview's life.
+  const overlayOpenRef = useRef(overlayOpen);
+  overlayOpenRef.current = overlayOpen;
+
+  // Webview lifecycle: create on entering web mode (or when the article's URL
+  // changes), destroy on leaving. Bounds track the host across resizes even
+  // while hidden, so re-showing never lands the page at a stale rect.
   useEffect(() => {
     const host = pageHostRef.current;
-    if (viewMode !== "web" || !articleUrl || !host || overlayOpen) return;
+    if (viewMode !== "web" || !articleUrl || !host) return;
 
     const bounds = () => {
       const r = host.getBoundingClientRect();
@@ -264,7 +275,13 @@ export default function Reader({ onToast }: Props) {
         // If teardown ran while this open was still in flight, the cleanup's
         // closePageView fired against a not-yet-created webview (a no-op) and
         // would leave this one orphaned above the DOM — close it now.
-        if (cancelled) api.closePageView().catch(() => {});
+        if (cancelled) {
+          api.closePageView().catch(() => {});
+          return;
+        }
+        // Created visible by default; if an overlay is already up (e.g. the AI
+        // drawer was open when web mode was toggled on), hide it at once.
+        if (overlayOpenRef.current) api.setPageViewVisible(false).catch(() => {});
       },
       () => {},
     );
@@ -282,7 +299,14 @@ export default function Reader({ onToast }: Props) {
       window.removeEventListener("resize", sync);
       api.closePageView().catch(() => {});
     };
-  }, [viewMode, articleUrl, overlayOpen]);
+  }, [viewMode, articleUrl]);
+
+  // Visibility: toggle the webview as overlays come and go, without reloading.
+  // No-op (backend-side) when no webview is open.
+  useEffect(() => {
+    if (viewMode !== "web" || !articleUrl) return;
+    api.setPageViewVisible(!overlayOpen).catch(() => {});
+  }, [overlayOpen, viewMode, articleUrl]);
 
   // Recover article-body images the webview fails to load, then hide the
   // stragglers. The webview sends no Referer (see sanitize.rs) — right for

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -25,18 +25,20 @@ interface Props {
   onAddFeed: () => void;
 }
 
-// `labelKey` holds an i18n key — resolved with t() at render time.
-const SECTIONS: { id: string; labelKey: string; icon: IconName; color: string }[] = [
-  { id: "general", labelKey: "settings.nav.general", icon: "settings", color: "#7a756c" },
-  { id: "appearance", labelKey: "settings.nav.appearance", icon: "globe", color: "#bb6743" },
-  { id: "reading", labelKey: "settings.nav.reading", icon: "eye", color: "#3a4cb8" },
-  { id: "subscriptions", labelKey: "settings.nav.subscriptions", icon: "rss", color: "#d97706" },
-  { id: "filters", labelKey: "settings.nav.filters", icon: "mute", color: "#9333ea" },
-  { id: "sync", labelKey: "settings.nav.sync", icon: "refresh", color: "#2c8a3e" },
-  { id: "shortcuts", labelKey: "settings.nav.shortcuts", icon: "command", color: "#5a5fc4" },
-  { id: "notifications", labelKey: "settings.nav.notifications", icon: "inbox", color: "#a8501f" },
-  { id: "advanced", labelKey: "settings.nav.advanced", icon: "sort", color: "#4a4a4a" },
-  { id: "about", labelKey: "settings.nav.about", icon: "sparkle", color: "#111" },
+// `labelKey` holds an i18n key — resolved with t() at render time. Nav icons
+// stay monochrome (quiet ink, accent only on the active row) — one accent,
+// used rarely, never a decorative rainbow of per-section colours.
+const SECTIONS: { id: string; labelKey: string; icon: IconName }[] = [
+  { id: "general", labelKey: "settings.nav.general", icon: "settings" },
+  { id: "appearance", labelKey: "settings.nav.appearance", icon: "globe" },
+  { id: "reading", labelKey: "settings.nav.reading", icon: "eye" },
+  { id: "subscriptions", labelKey: "settings.nav.subscriptions", icon: "rss" },
+  { id: "filters", labelKey: "settings.nav.filters", icon: "mute" },
+  { id: "sync", labelKey: "settings.nav.sync", icon: "refresh" },
+  { id: "shortcuts", labelKey: "settings.nav.shortcuts", icon: "command" },
+  { id: "notifications", labelKey: "settings.nav.notifications", icon: "inbox" },
+  { id: "advanced", labelKey: "settings.nav.advanced", icon: "sort" },
+  { id: "about", labelKey: "settings.nav.about", icon: "sparkle" },
 ];
 
 /** The app version read from the Tauri bundle config at runtime, cached so the
@@ -120,8 +122,8 @@ export default function SettingsDialog({
               className={`settings-nav-item ${section === s.id ? "active" : ""}`}
               onClick={() => setSection(s.id)}
             >
-              <span className="nav-ico" style={{ background: s.color }}>
-                <Icon name={s.icon} size={11} color="#fff" />
+              <span className="nav-ico">
+                <Icon name={s.icon} size={15} />
               </span>
               {t(s.labelKey)}
             </div>
@@ -552,21 +554,12 @@ function AppearanceSection() {
   const setTheme = useUi((s) => s.setTheme);
   const darkShade = useUi((s) => s.darkShade);
   const setDarkShade = useUi((s) => s.setDarkShade);
-  const accent = useUi((s) => s.accent);
-  const setAccent = useUi((s) => s.setAccent);
   const density = useUi((s) => s.density);
   const setDensity = useUi((s) => s.setDensity);
   const viewMode = useUi((s) => s.viewMode);
   const setViewMode = useUi((s) => s.setViewMode);
   const prefs = useUi((s) => s.prefs);
   const setPref = useUi((s) => s.setPref);
-
-  const accents = [
-    { value: "clay", color: "#bb6743", label: t("settings.appearance.accentClay") },
-    { value: "pine", color: "#3d7a5e", label: t("settings.appearance.accentPine") },
-    { value: "indigo", color: "#5a5fc4", label: t("settings.appearance.accentIndigo") },
-    { value: "ink", color: "#2b2620", label: t("settings.appearance.accentInk") },
-  ] as const;
 
   return (
     <>
@@ -614,24 +607,6 @@ function AppearanceSection() {
             />
           </Row>
         )}
-        <Row
-          label={t("settings.appearance.accent")}
-          desc={t("settings.appearance.accentDesc")}
-        >
-          <div className="s-swatches" role="group">
-            {accents.map((a) => (
-              <button
-                key={a.value}
-                className={`s-swatch ${accent === a.value ? "on" : ""}`}
-                style={{ background: a.color }}
-                onClick={() => setAccent(a.value)}
-                title={a.label}
-                aria-label={a.label}
-                aria-pressed={accent === a.value}
-              />
-            ))}
-          </div>
-        </Row>
       </div>
       <div className="settings-group">
         <h3 className="settings-group-title">{t("settings.appearance.layout")}</h3>
@@ -1581,6 +1556,8 @@ function DangerZone({ onToast }: { onToast: (m: string) => void }) {
         if (
           k.startsWith("pref.") ||
           [
+            // "accent" is intentionally still cleared: it removes any value
+            // persisted by older builds that exposed an accent picker.
             "theme", "accent", "density", "viewMode", "readerFont", "useSerif",
             "readerSize", "readerLeading", "readerWidth", "collapsedFolders",
           ].includes(k)

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -553,8 +553,6 @@ function AppearanceSection() {
   const { t, i18n } = useTranslation();
   const theme = useUi((s) => s.theme);
   const setTheme = useUi((s) => s.setTheme);
-  const darkShade = useUi((s) => s.darkShade);
-  const setDarkShade = useUi((s) => s.setDarkShade);
   const density = useUi((s) => s.density);
   const setDensity = useUi((s) => s.setDensity);
   const viewMode = useUi((s) => s.viewMode);
@@ -592,22 +590,6 @@ function AppearanceSection() {
             onChange={setTheme}
           />
         </Row>
-        {theme === "dark" && (
-          <Row
-            label={t("settings.appearance.darkShade")}
-            desc={t("settings.appearance.darkShadeDesc")}
-          >
-            <Segmented
-              value={darkShade}
-              options={[
-                { value: "default", label: t("settings.appearance.darkShadeDefault") },
-                { value: "dimmer", label: t("settings.appearance.darkShadeDimmer") },
-                { value: "black", label: t("settings.appearance.darkShadeBlack") },
-              ]}
-              onChange={setDarkShade}
-            />
-          </Row>
-        )}
       </div>
       <div className="settings-group">
         <h3 className="settings-group-title">{t("settings.appearance.layout")}</h3>
@@ -1560,10 +1542,12 @@ function DangerZone({ onToast }: { onToast: (m: string) => void }) {
         if (
           k.startsWith("pref.") ||
           [
-            // "accent" is intentionally still cleared: it removes any value
-            // persisted by older builds that exposed an accent picker.
-            "theme", "accent", "density", "viewMode", "readerFont", "useSerif",
-            "readerSize", "readerLeading", "readerWidth", "collapsedFolders",
+            // "accent" / "darkShade" are intentionally still cleared: they
+            // remove any value persisted by older builds that exposed an
+            // accent picker / dark-shade picker.
+            "theme", "accent", "darkShade", "density", "viewMode", "readerFont",
+            "useSerif", "readerSize", "readerLeading", "readerWidth",
+            "collapsedFolders",
           ].includes(k)
         ) {
           localStorage.removeItem(k);

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -13,6 +13,7 @@ import { modKey, modCombo } from "../lib/platform";
 import { reportError } from "../toast";
 import { checkForUpdates } from "../lib/updater";
 import { downloadFile } from "../lib/download";
+import { NO_AUTOCORRECT } from "../lib/inputProps";
 import type { Feed, Rule, RuleAction, RuleField, RulePreview } from "../types";
 import Icon, { type IconName } from "./Icon";
 import ConfirmDialog from "./ConfirmDialog";
@@ -866,6 +867,7 @@ function SubscriptionsSection({
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder={t("settings.subscriptions.searchPlaceholder")}
+              {...NO_AUTOCORRECT}
               style={{
                 flex: 1,
                 border: 0,
@@ -980,9 +982,7 @@ function RsshubInstanceGroup() {
             if (e.key === "Enter") e.currentTarget.blur();
           }}
           placeholder="https://rsshub.app"
-          spellCheck={false}
-          autoCapitalize="off"
-          autoCorrect="off"
+          {...NO_AUTOCORRECT}
           style={{
             width: 220,
             padding: "5px 9px",
@@ -1141,6 +1141,7 @@ function SyncSection({ onToast }: { onToast: (m: string) => void }) {
                 className="modal-input"
                 style={{ margin: 0 }}
                 placeholder={t("settings.sync.serverPlaceholder")}
+                {...NO_AUTOCORRECT}
                 value={url}
                 onChange={(e) => setUrl(e.target.value)}
               />
@@ -1148,6 +1149,7 @@ function SyncSection({ onToast }: { onToast: (m: string) => void }) {
                 className="modal-input"
                 style={{ margin: 0 }}
                 placeholder={t("settings.sync.userPlaceholder")}
+                {...NO_AUTOCORRECT}
                 value={user}
                 onChange={(e) => setUser(e.target.value)}
               />
@@ -1160,6 +1162,7 @@ function SyncSection({ onToast }: { onToast: (m: string) => void }) {
                     ? t("settings.sync.appPassPlaceholder")
                     : t("settings.sync.passPlaceholder")
                 }
+                {...NO_AUTOCORRECT}
                 value={pass}
                 onChange={(e) => setPass(e.target.value)}
               />
@@ -1501,6 +1504,7 @@ function NetworkGroup({ onToast }: { onToast: (m: string) => void }) {
         >
           <input
             className="s-text-input"
+            {...NO_AUTOCORRECT}
             value={customProxy}
             placeholder="http://host:port"
             onChange={(e) => setCustomProxy(e.target.value)}
@@ -1744,6 +1748,7 @@ function AiSettingsGroup({ onToast }: { onToast: (m: string) => void }) {
         <input
           className="s-text-input"
           type="password"
+          {...NO_AUTOCORRECT}
           value={apiKey}
           placeholder="sk-…"
           onChange={(e) => setApiKey(e.target.value)}
@@ -1766,6 +1771,7 @@ function AiSettingsGroup({ onToast }: { onToast: (m: string) => void }) {
         <input
           className="s-text-input"
           type="text"
+          {...NO_AUTOCORRECT}
           value={model}
           placeholder={placeholder}
           onChange={(e) => setModel(e.target.value)}
@@ -1788,6 +1794,7 @@ function AiSettingsGroup({ onToast }: { onToast: (m: string) => void }) {
         <input
           className="s-text-input"
           type="text"
+          {...NO_AUTOCORRECT}
           value={baseUrl}
           placeholder={baseUrlPlaceholder}
           onChange={(e) => setBaseUrl(e.target.value)}
@@ -2094,12 +2101,14 @@ function RuleEditor({
     <div className="rule-card">
       <input
         className="rule-input"
+        {...NO_AUTOCORRECT}
         value={name}
         onChange={(e) => setName(e.target.value)}
         placeholder={t("settings.filters.namePlaceholder")}
       />
       <input
         className="rule-input"
+        {...NO_AUTOCORRECT}
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         placeholder={t("settings.filters.queryPlaceholder")}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import * as api from "../api";
 import { useUi } from "../store";
@@ -203,6 +203,33 @@ export default function Sidebar({
   const allFolders = folders.data ?? [];
   const allTags = tags.data ?? [];
   const isActive = (q: ArticleQuery) => sameQuery(q, query);
+
+  // Keep the selected feed in view. Opening an article from search jumps the
+  // selection to a feed that may be scrolled out of sight — or hidden inside a
+  // collapsed folder — so reveal it whenever the selection changes (issue #75).
+  // `block: "nearest"` is a no-op when the row is already visible, so a plain
+  // in-sidebar click never jolts the list.
+  const activeFeedRef = useRef<HTMLDivElement>(null);
+  // Remember which selection we last scrolled to, so a background feeds refetch
+  // or an unrelated folder toggle (both re-run this effect) doesn't yank the
+  // list back to the active feed.
+  const lastScrolledRef = useRef("");
+  useEffect(() => {
+    const key = JSON.stringify(query);
+    if (key === lastScrolledRef.current) return;
+    if (query.kind === "feed") {
+      const feed = allFeeds.find((f) => f.id === query.value);
+      // A collapsed folder doesn't render its feed rows, so there's nothing to
+      // scroll to yet — expand it and let this effect re-run (collapsed dep)
+      // once the row is mounted.
+      if (feed?.folderId != null && collapsed[feed.folderId]) {
+        setCollapsed((s) => ({ ...s, [feed.folderId!]: false }));
+        return;
+      }
+    }
+    lastScrolledRef.current = key;
+    activeFeedRef.current?.scrollIntoView({ block: "nearest" });
+  }, [query, allFeeds, collapsed]);
 
   // "Unread only" hides feeds with nothing unread, decluttering large
   // sidebars. The currently-selected feed is always kept so it doesn't vanish
@@ -473,6 +500,7 @@ export default function Sidebar({
   const feedRow = (f: Feed) => (
     <div
       key={f.id}
+      ref={isActive({ kind: "feed", value: f.id }) ? activeFeedRef : undefined}
       className={`sb-item ${
         isActive({ kind: "feed", value: f.id }) ? "active" : ""
       } ${dragId === f.id ? "dragging" : ""}`}

--- a/src/components/TagPicker.tsx
+++ b/src/components/TagPicker.tsx
@@ -6,6 +6,7 @@ import { useDismiss } from "../hooks/useDismiss";
 import { reportError } from "../toast";
 import { tagColor } from "../lib/tagColors";
 import { clampToViewport } from "../lib/viewport";
+import { NO_AUTOCORRECT } from "../lib/inputProps";
 import Icon from "./Icon";
 
 interface Props {
@@ -127,6 +128,7 @@ export default function TagPicker({
           }}
           placeholder={t("tagPicker.createPlaceholder")}
           aria-label={t("tagPicker.createPlaceholder")}
+          {...NO_AUTOCORRECT}
         />
         <button onClick={createAndAttach} disabled={!draft.trim()}>
           <Icon name="plus" size={13} />

--- a/src/lib/currentList.ts
+++ b/src/lib/currentList.ts
@@ -7,9 +7,13 @@ import { useUi } from "../store";
 import type { ArticleSummary } from "../types";
 
 export function readCurrentItems(qc: QueryClient): ArticleSummary[] {
-  const { query, unreadOnly, sortOldest } = useUi.getState();
-  const inf = qc.getQueryData(["articles", query, unreadOnly, sortOldest]) as
-    | { pages: ArticleSummary[][] }
-    | undefined;
+  const { query, unreadOnly, sortOldest, listAnchor } = useUi.getState();
+  const inf = qc.getQueryData([
+    "articles",
+    query,
+    unreadOnly,
+    sortOldest,
+    listAnchor,
+  ]) as { pages: ArticleSummary[][] } | undefined;
   return inf?.pages.flat() ?? [];
 }

--- a/src/lib/inputProps.ts
+++ b/src/lib/inputProps.ts
@@ -1,0 +1,12 @@
+// Props that silence the macOS WebKit autocorrect / autocapitalize / spell-check
+// / autofill machinery on a free-text field. On macOS, Tauri renders through
+// WKWebView, which forces these on by default: it underlines and rewrites text,
+// auto-capitalizes the first letter, and pops a browser history dropdown — all
+// of which fight the IME's own candidate window, especially for CJK input.
+// Spread onto every free-text <input> (search boxes, names, URLs, credentials).
+export const NO_AUTOCORRECT = {
+  autoComplete: "off",
+  autoCorrect: "off",
+  autoCapitalize: "off",
+  spellCheck: false,
+} as const;

--- a/src/store.ts
+++ b/src/store.ts
@@ -108,6 +108,14 @@ interface UiState {
   unreadOnly: boolean;
   /** Sort the list oldest-first instead of newest-first. */
   sortOldest: boolean;
+  /** Offset of the first page the middle-pane list loads — its paging anchor.
+   *  Normally 0 (newest first). Opening an article from search that lives far
+   *  down the list jumps the anchor to that article's page so the list loads
+   *  *only* that page and pages outward from there, instead of every page above
+   *  it. Part of the list's React Query key, so `currentList` reads the same
+   *  window the user sees. Reset to 0 on any list-context change (feed / filter
+   *  / sort). */
+  listAnchor: number;
 
   // appearance preferences
   theme: Theme;
@@ -145,6 +153,7 @@ interface UiState {
   openArticle: (id: number | null) => void;
   toggleUnreadOnly: () => void;
   toggleSort: () => void;
+  setListAnchor: (offset: number) => void;
 
   setTheme: (t: Theme) => void;
   setDarkShade: (s: DarkShade) => void;
@@ -224,6 +233,7 @@ export const useUi = create<UiState>((set) => ({
   selectedArticleId: null,
   unreadOnly: false,
   sortOldest: false,
+  listAnchor: 0,
 
   theme: ls.oneOf<Theme>("theme", ["light", "dark"], "light"),
   darkShade: ls.oneOf<DarkShade>(
@@ -262,11 +272,14 @@ export const useUi = create<UiState>((set) => ({
     // Remember the selection so the "open on startup: last view" preference
     // can restore it next launch.
     ls.set("lastView", JSON.stringify({ query, label }));
-    set({ query, queryLabel: label, selectedArticleId: null });
+    // Reset the paging anchor: a new selection always opens at the newest page.
+    set({ query, queryLabel: label, selectedArticleId: null, listAnchor: 0 });
   },
   openArticle: (id) => set({ selectedArticleId: id }),
-  toggleUnreadOnly: () => set((s) => ({ unreadOnly: !s.unreadOnly })),
-  toggleSort: () => set((s) => ({ sortOldest: !s.sortOldest })),
+  // Toggling a filter/sort rebuilds the list, so re-anchor to the newest page.
+  toggleUnreadOnly: () => set((s) => ({ unreadOnly: !s.unreadOnly, listAnchor: 0 })),
+  toggleSort: () => set((s) => ({ sortOldest: !s.sortOldest, listAnchor: 0 })),
+  setListAnchor: (listAnchor) => set({ listAnchor }),
 
   setTheme: (theme) => { ls.set("theme", theme); mirrorTheme(theme); set({ theme }); },
   setDarkShade: (darkShade) => { ls.set("darkShade", darkShade); mirrorDarkShade(darkShade); set({ darkShade }); },

--- a/src/store.ts
+++ b/src/store.ts
@@ -11,7 +11,6 @@ export type Theme = "light" | "dark";
 /** Background depth for the dark theme. Only meaningful while `theme` is
  *  "dark"; lets users pick a darker paper than the default warm charcoal. */
 export type DarkShade = "default" | "dimmer" | "black";
-export type Accent = "clay" | "pine" | "indigo" | "ink";
 export type Density = "compact" | "cozy" | "spacious";
 export type ViewMode = "list" | "card";
 export type StartupView = "all" | "unread" | "starred" | "last";
@@ -113,7 +112,6 @@ interface UiState {
   // appearance preferences
   theme: Theme;
   darkShade: DarkShade;
-  accent: Accent;
   density: Density;
   viewMode: ViewMode;
   readerFont: ReaderFont;
@@ -137,6 +135,11 @@ interface UiState {
    *  DOM — including modals — so it must be torn down while one is up, or it
    *  occludes the dialog (issue #54). The reader effect watches this flag. */
   modalOpen: boolean;
+  /** A floating context menu is open. Same hazard as `modalOpen`: a context
+   *  menu raised over the reading area would be occluded by the native
+   *  original-page webview that floats above the DOM (issue #74), so the
+   *  reader suspends that view while a menu is up. */
+  menuOpen: boolean;
 
   select: (query: ArticleQuery, label: string) => void;
   openArticle: (id: number | null) => void;
@@ -145,7 +148,6 @@ interface UiState {
 
   setTheme: (t: Theme) => void;
   setDarkShade: (s: DarkShade) => void;
-  setAccent: (a: Accent) => void;
   setDensity: (d: Density) => void;
   setViewMode: (v: ViewMode) => void;
   setReaderFont: (v: ReaderFont) => void;
@@ -157,6 +159,7 @@ interface UiState {
   setFocusMode: (v: boolean) => void;
   setAiOpen: (v: boolean) => void;
   setModalOpen: (v: boolean) => void;
+  setMenuOpen: (v: boolean) => void;
 }
 
 const PREF_KEYS: (keyof Prefs)[] = [
@@ -228,7 +231,6 @@ export const useUi = create<UiState>((set) => ({
     ["default", "dimmer", "black"],
     "default",
   ),
-  accent: ls.oneOf<Accent>("accent", ["clay", "pine", "indigo", "ink"], "clay"),
   density: ls.oneOf<Density>(
     "density",
     ["compact", "cozy", "spacious"],
@@ -254,6 +256,7 @@ export const useUi = create<UiState>((set) => ({
   focusMode: false,
   aiOpen: false,
   modalOpen: false,
+  menuOpen: false,
 
   select: (query, label) => {
     // Remember the selection so the "open on startup: last view" preference
@@ -267,7 +270,6 @@ export const useUi = create<UiState>((set) => ({
 
   setTheme: (theme) => { ls.set("theme", theme); mirrorTheme(theme); set({ theme }); },
   setDarkShade: (darkShade) => { ls.set("darkShade", darkShade); mirrorDarkShade(darkShade); set({ darkShade }); },
-  setAccent: (accent) => { ls.set("accent", accent); set({ accent }); },
   setDensity: (density) => { ls.set("density", density); set({ density }); },
   setViewMode: (viewMode) => { ls.set("viewMode", viewMode); set({ viewMode }); },
   setReaderFont: (readerFont) => { ls.set("readerFont", readerFont); set({ readerFont }); },
@@ -323,6 +325,7 @@ export const useUi = create<UiState>((set) => ({
   setFocusMode: (focusMode) => set({ focusMode }),
   setAiOpen: (aiOpen) => set({ aiOpen }),
   setModalOpen: (modalOpen) => set({ modalOpen }),
+  setMenuOpen: (menuOpen) => set({ menuOpen }),
 }));
 
 // Seed the backend's theme copy on startup so an existing install — whose

--- a/src/store.ts
+++ b/src/store.ts
@@ -10,7 +10,6 @@ import type { ArticleQuery } from "./types";
 export type Theme = "light" | "dark";
 /** Background depth for the dark theme. Only meaningful while `theme` is
  *  "dark"; lets users pick a darker paper than the default warm charcoal. */
-export type DarkShade = "default" | "dimmer" | "black";
 export type Density = "compact" | "cozy" | "spacious";
 export type ViewMode = "list" | "card";
 export type StartupView = "all" | "unread" | "starred" | "last";
@@ -119,7 +118,6 @@ interface UiState {
 
   // appearance preferences
   theme: Theme;
-  darkShade: DarkShade;
   density: Density;
   viewMode: ViewMode;
   readerFont: ReaderFont;
@@ -156,7 +154,6 @@ interface UiState {
   setListAnchor: (offset: number) => void;
 
   setTheme: (t: Theme) => void;
-  setDarkShade: (s: DarkShade) => void;
   setDensity: (d: Density) => void;
   setViewMode: (v: ViewMode) => void;
   setReaderFont: (v: ReaderFont) => void;
@@ -194,10 +191,12 @@ function mirrorTheme(theme: Theme): void {
   api.setSetting("theme", theme).catch(() => {});
 }
 
-/** Mirror the dark-shade choice to the backend so the native window can be
- *  painted in the matching colour before the first webview frame (lib.rs). */
-function mirrorDarkShade(shade: DarkShade): void {
-  api.setSetting("dark_shade", shade).catch(() => {});
+/** Pin the backend's `dark_shade` to the single shipped shade so the native
+ *  window paints the matching colour before the first webview frame (lib.rs),
+ *  and any value persisted by an older build that exposed a shade picker is
+ *  normalised back to "default". */
+function mirrorDarkShade(): void {
+  api.setSetting("dark_shade", "default").catch(() => {});
 }
 
 /** Resolve the persisted reader font, migrating the pre-0.2 boolean
@@ -236,11 +235,6 @@ export const useUi = create<UiState>((set) => ({
   listAnchor: 0,
 
   theme: ls.oneOf<Theme>("theme", ["light", "dark"], "light"),
-  darkShade: ls.oneOf<DarkShade>(
-    "darkShade",
-    ["default", "dimmer", "black"],
-    "default",
-  ),
   density: ls.oneOf<Density>(
     "density",
     ["compact", "cozy", "spacious"],
@@ -282,7 +276,6 @@ export const useUi = create<UiState>((set) => ({
   setListAnchor: (listAnchor) => set({ listAnchor }),
 
   setTheme: (theme) => { ls.set("theme", theme); mirrorTheme(theme); set({ theme }); },
-  setDarkShade: (darkShade) => { ls.set("darkShade", darkShade); mirrorDarkShade(darkShade); set({ darkShade }); },
   setDensity: (density) => { ls.set("density", density); set({ density }); },
   setViewMode: (viewMode) => { ls.set("viewMode", viewMode); set({ viewMode }); },
   setReaderFont: (readerFont) => { ls.set("readerFont", readerFont); set({ readerFont }); },
@@ -345,4 +338,4 @@ export const useUi = create<UiState>((set) => ({
 // theme has lived only in localStorage until now — still gets the native
 // launch background themed correctly from the next launch onward.
 mirrorTheme(useUi.getState().theme);
-mirrorDarkShade(useUi.getState().darkShade);
+mirrorDarkShade();

--- a/src/styles.css
+++ b/src/styles.css
@@ -62,25 +62,23 @@
 
 [data-theme="dark"] {
   color-scheme: dark;
-  /* "Editorial Quiet", dark. The chrome (window, sidebar, list) stays cool and
-     near-neutral; warmth is reserved for the reading surface so the page reads
-     as a sheet of lamp-lit paper and the rest recedes. Crucially the surfaces
-     now STEP in lightness — sidebar darkest, list lighter, reader lightest —
-     instead of sitting at one flat tone, so the three panes read as depth, not
-     a single grey field. The reader also carries roughly double the chroma so
-     it alone feels like paper, not metal.
-     Hue note: every surface sits at oklch hue ~40-42 (red-leaning terracotta),
-     NOT 55-66. On a near-black field a warm hue past ~50 reads as dirty yellow/
-     khaki ("淡淡的黄") — keeping the tint red-leaning and very low-chroma gives
-     warmth without ever going yellow. Do not raise these hues back toward 60. */
+  /* "Editorial Quiet", dark. ALL surfaces are one cohesive NEUTRAL graphite
+     family (hue ~250, chroma ≈0). They STEP in lightness — window floor
+     darkest, sidebar, list, reader lightest — so the panes read as depth, not
+     one flat grey. An earlier scheme warmed the chrome (hue 40) and the reader
+     separately; the reader read as a milk-coffee patch and, once neutralised,
+     left the warm chrome looking mismatched beside it. Keeping every surface
+     neutral graphite is what makes the three panes finally sit together.
+     Warmth now lives ONLY in the terracotta accent (below) — one accent, used
+     rarely. Keep surface chroma ≈0; do not re-warm any pane toward hue 40. */
   /* hex, not oklch: this var paints the root `html` background, and a
      root-propagated oklch viewport background flashes white in the strip
      WebKit exposes during a live window resize. The other surfaces below stay
      oklch — they sit on child elements, not the viewport, so they're unaffected. */
-  --paper: #0e0c0b;                 /* window floor, deepest */
-  --panel: oklch(0.190 0.005 40);   /* #161312 — sidebar, recedes */
-  --panel-2: oklch(0.230 0.005 40); /* #1f1c1b — list rows + floating menus */
-  --reader: oklch(0.250 0.008 42);  /* #25201f — reading surface, warm & lit */
+  --paper: #0A0B0C;                 /* window floor, deepest */
+  --panel: oklch(0.190 0.002 250);  /* #131415 — sidebar, recedes */
+  --panel-2: oklch(0.215 0.002 250);/* #19191a — list rows + floating menus */
+  --reader: oklch(0.235 0.002 250); /* #1d1e1f — reading surface, lightest */
 
   --ink: oklch(0.930 0.006 50);     /* #ebe7e4 — soft warm white, never #fff */
   --ink-2: oklch(0.800 0.006 48);
@@ -114,24 +112,6 @@
   --shadow-pop: 0 14px 38px oklch(0.05 0.006 40 / 0.6);
   --shadow-modal: 0 26px 64px oklch(0.04 0.005 40 / 0.68);
   --shadow-ring: 0 0 0 1px oklch(0 0 0 / 0.3);
-}
-
-/* Dark-shade overrides — only the surface colours change, keeping the warm
-   hue; ink, accents and borders stay as the base dark theme defines them.
-   "default" needs no block (it uses the values above). */
-[data-theme="dark"][data-dark-shade="dimmer"] {
-  --paper: #060504;                 /* hex — root background, see note above */
-  --panel: oklch(0.150 0.005 40);   /* #0d0a0a */
-  --panel-2: oklch(0.190 0.005 40); /* #161312 */
-  --reader: oklch(0.210 0.008 42);  /* #1c1715 — reader stays warm & lifted */
-}
-[data-theme="dark"][data-dark-shade="black"] {
-  /* True-black window for OLED — but the panes keep stepping up and the reader
-     stays a warm lit sheet, so it never collapses into flat grey-on-black. */
-  --paper: #000000;
-  --panel: oklch(0.105 0.004 40);   /* #050403 */
-  --panel-2: oklch(0.150 0.005 40); /* #0d0a0a */
-  --reader: oklch(0.180 0.008 42);  /* #15100f */
 }
 
 /* ── Dark theme: accent as a mark, not a fill ──────────────────────────────

--- a/src/styles.css
+++ b/src/styles.css
@@ -1443,13 +1443,17 @@ button { font-family: inherit; }
 }
 .settings-nav-item .nav-ico {
   width: 18px; height: 18px;
-  border-radius: 5px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: #fff;
+  color: var(--muted);
   flex-shrink: 0;
+  transition: color .12s;
 }
+/* One accent, used rarely: only the selected section's icon picks up the
+   terracotta, matching its label — the rest stay a quiet, even ink. */
+.settings-nav-item:hover .nav-ico { color: var(--ink-2); }
+.settings-nav-item.active .nav-ico { color: inherit; }
 .settings-nav-spacer { flex: 1; }
 .settings-version {
   padding: 8px 12px 4px;
@@ -1652,32 +1656,6 @@ button { font-family: inherit; }
   background: var(--panel-2);
   color: var(--ink);
   box-shadow: 0 1px 2px oklch(0.15 0.03 50 / 0.09);
-}
-
-/* Color swatches */
-.s-swatches {
-  display: inline-flex;
-  gap: 8px;
-}
-.s-swatch {
-  width: 22px; height: 22px;
-  border-radius: 11px;
-  cursor: pointer;
-  border: 2px solid transparent;
-  outline: 1px solid var(--hair-strong);
-  outline-offset: -1px;
-  padding: 0;
-  position: relative;
-}
-.s-swatch.on {
-  outline-color: var(--ink-2);
-  outline-width: 1.5px;
-  outline-offset: 2px;
-}
-/* The swatch uses `outline` for its own border, which would suppress the UA
-   focus ring — give keyboard focus a distinct box-shadow halo instead. */
-.s-swatch:focus-visible {
-  box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
 /* Button */


### PR DESCRIPTION
Fixes #74. Fixes #75.

Opening an article from command-palette search left the rest of the UI out of step with the article shown in the reader. This branch syncs all three panes and bundles a few related UI fixes.

### Bug fixes
- **#75 — sidebar feed card now tracks the search result**: auto-scroll the selected feed into view, expanding its folder first when collapsed.
- **#74 — context menu no longer occluded by the original-page view**: the original-page view is a native child webview floating above the DOM, so a right-click menu over the reader was hidden behind it. Hide (not tear down) the webview while any menu / modal / AI drawer is up, via a new `set_page_view_visible` command, so the page reappears instantly without reloading.
- **Article list paging**: a searched article often isn't in the loaded window (paged out, or hidden by "unread only"). Add a backend `article_index` to find its rank, anchor the list's now-bidirectional lazy paging to that page, drop the unread filter when it would hide the article, and re-centre the row until the long page finishes measuring.

### Other changes on this branch
- `da111d5` don't scroll a clicked article to centre
- `bb400a6` unify dark surfaces to neutral graphite; drop dark-shade picker
- `3b2982b` silence macOS WebKit autocorrect on free-text fields
- `5d3ca1b` rounder modern icon set; quiet Settings; fix accent


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a way to jump to an article’s position in the current list.
  * The reader now keeps the in-app page view hidden whenever overlays or menus are open.
  * Active items in the sidebar are revealed automatically when navigating.

* **Bug Fixes**
  * Improved article list paging and scroll behavior for smoother loading in both directions.
  * Fixed selection handling so filtered-out articles can still be found by relaxing filters when needed.
  * Updated text inputs across the app to reduce autocorrect interference and improve typing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->