### PR TITLE
chore(release): v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,7 +3400,7 @@ dependencies = [
 
 [[package]]
 name = "papr"
-version = "0.12.0-beta.1"
+version = "0.12.0"
 dependencies = [
  "ammonia",
  "anyhow",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "papr-cli"
-version = "0.12.0-beta.1"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "clap",
@@ -3455,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "papr-core"
-version = "0.12.0-beta.1"
+version = "0.12.0"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/crates/papr-cli/Cargo.toml
+++ b/crates/papr-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "papr-cli"
-version = "0.12.0-beta.1"
+version = "0.12.0"
 edition = "2021"
 description = "papr — an agent-facing CLI over your Papr RSS feeds: read, search, triage and refresh from the shell."
 

--- a/crates/papr-core/Cargo.toml
+++ b/crates/papr-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "papr-core"
-version = "0.12.0-beta.1"
+version = "0.12.0"
 edition = "2021"
 description = "Papr's UI-free core: SQLite data layer, feed ingestion, and content sanitization. Shared by the desktop app and the agent CLI."
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "papr",
   "private": true,
-  "version": "0.12.0-beta.1",
+  "version": "0.12.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "papr"
-version = "0.12.0-beta.1"
+version = "0.12.0"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "papr"
-version = "0.12.0-beta.1"
+version = "0.12.0"
 description = "Papr — a modern RSS reader"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Papr",
-  "version": "0.12.0-beta.1",
+  "version": "0.12.0",
   "identifier": "com.thomas.papr",
   "mainBinaryName": "papr-desktop",
   "build": {


### PR DESCRIPTION
Promote `v0.12.0-beta.1` → stable **v0.12.0**. Bumps every workspace crate, the Tauri config and `package.json` to 0.12.0; both lockfiles re-synced (member version entries only).

Includes the search-navigation pane sync fixes (#74, #75) merged in #82.

Merging this, then pushing tag `v0.12.0`, triggers the release build (all four platforms, signed) and the Homebrew tap sync.