### PR TITLE
fix: eliminate dark-theme window resize flash on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3019,9 +3019,17 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.13.0",
  "block2",
+ "libc",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
  "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]
@@ -3041,6 +3049,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
+ "bitflags 2.13.0",
  "objc2",
  "objc2-foundation",
 ]
@@ -3102,6 +3111,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3141,6 +3163,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-javascript-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a1e6550c4caed348956ce3370c9ffeca70bb1dbed4fa96112e7c6170e074586"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-osa-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3162,6 +3194,17 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -3207,6 +3250,8 @@ dependencies = [
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-foundation",
+ "objc2-javascript-core",
+ "objc2-security",
 ]
 
 [[package]]
@@ -3415,7 +3460,9 @@ dependencies = [
  "lol_html",
  "mail-parser",
  "objc2",
+ "objc2-app-kit",
  "objc2-foundation",
+ "objc2-web-kit",
  "opml",
  "papr-core",
  "reqwest 0.12.28",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -98,3 +98,8 @@ log = "0.4"
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
 objc2-foundation = "0.3"
+# Typed handles to the WKWebView / NSWindow / NSColor we repaint per theme to
+# kill the resize flash (see src/backing.rs). Versions track tauri/wry's own
+# objc2 to keep a single copy in the tree.
+objc2-web-kit = { version = "0.3", features = ["WKWebView"] }
+objc2-app-kit = { version = "0.3", features = ["NSColor", "NSWindow", "NSView", "NSResponder"] }

--- a/src-tauri/src/backing.rs
+++ b/src-tauri/src/backing.rs
@@ -1,0 +1,90 @@
+//! Native window + webview backing colour (macOS resize-flash fix).
+//!
+//! On macOS wry builds the WKWebView with `drawsBackground = YES` — an opaque
+//! WHITE backing — unless its `transparent` cargo feature is on, which we don't
+//! enable. During a *live* window resize the renderer lags the new frame and the
+//! freshly-exposed strip at the dragged edge shows white. On a dark theme that
+//! is the "fast-resize edge flash".
+//!
+//! The textbook fix (drawsBackground = NO + a themed NSWindow colour) is enough
+//! for a *default* window — the reference demo proves it. It is NOT enough here:
+//! our window is `titleBarStyle: "Overlay"` + `hiddenTitle`, i.e. macOS
+//! `fullSizeContentView`. That arrangement puts opaque container NSViews between
+//! the (now non-opaque) webview and the window, and during a resize the exposed
+//! strip shows whichever of those is opaque — by default an uninitialised WHITE
+//! backing — *before* the NSWindow colour is ever reached.
+//!
+//! So we paint, in the theme colour, every native surface that strip can show:
+//!   • `drawsBackground = NO` + `setOpaque: NO` — the page never paints its own
+//!     white backdrop and lets lower layers composite through.
+//!   • `underPageBackgroundColor` — the overscroll / resize *gutter* (macOS 12+),
+//!     which otherwise stays stuck on the light window-config colour.
+//!   • the CALayer of the webview **and every ancestor up to the window's
+//!     contentView** — this is what actually kills the white strip under the
+//!     Overlay titlebar. We stop at contentView so the titlebar frame
+//!     (NSThemeFrame) is left untouched.
+//!   • `NSWindow.backgroundColor` — the final layer behind everything.
+//!
+//! Called once in `setup()` with the saved theme's colour (before the first
+//! frame) and re-asserted from the frontend on every theme change via the
+//! `set_native_backing` command. See tauri-apps/tauri#14288.
+
+/// Pin every native surface a live resize can expose to `(r, g, b)`.
+#[cfg(target_os = "macos")]
+pub fn apply(window: &tauri::WebviewWindow, r: u8, g: u8, b: u8) {
+    let _ = window.with_webview(move |webview| unsafe {
+        use objc2::msg_send;
+        use objc2::runtime::AnyObject;
+        use objc2_app_kit::{NSColor, NSWindow};
+        use objc2_foundation::{NSNumber, NSString};
+        use objc2_web_kit::WKWebView;
+
+        let wk: &WKWebView = &*webview.inner().cast::<WKWebView>();
+        let wk_obj = wk as *const WKWebView as *mut AnyObject;
+
+        // 1) never paint the page's own (white) backdrop; let lower layers show.
+        let no = NSNumber::numberWithBool(false);
+        let key = NSString::from_str("drawsBackground");
+        let _: () = msg_send![wk_obj, setValue: &*no, forKey: &*key];
+        let _: () = msg_send![wk_obj, setOpaque: false];
+
+        let color = NSColor::colorWithSRGBRed_green_blue_alpha(
+            r as f64 / 255.0,
+            g as f64 / 255.0,
+            b as f64 / 255.0,
+            1.0,
+        );
+        let cg = color.CGColor();
+
+        // 2) the overscroll / live-resize gutter (macOS 12+).
+        let _: () = msg_send![wk_obj, setUnderPageBackgroundColor: &*color];
+
+        let ns_window: &NSWindow = &*webview.ns_window().cast::<NSWindow>();
+        let win_obj = ns_window as *const NSWindow as *mut AnyObject;
+        let content_view: *mut AnyObject = msg_send![win_obj, contentView];
+
+        // 3) paint the CALayer of the webview and every ancestor up to (and
+        //    including) the window's contentView — the opaque white container
+        //    layers the Overlay titlebar leaves between webview and window.
+        let mut v = wk_obj;
+        while !v.is_null() {
+            let _: () = msg_send![v, setWantsLayer: true];
+            let layer: *mut AnyObject = msg_send![v, layer];
+            if !layer.is_null() {
+                let _: () = msg_send![layer, setBackgroundColor: &*cg];
+            }
+            if v == content_view {
+                break; // stop before the titlebar frame (NSThemeFrame)
+            }
+            v = msg_send![v, superview];
+        }
+
+        // 4) the final layer behind everything.
+        ns_window.setBackgroundColor(Some(&color));
+    });
+}
+
+/// No native backing to manage off macOS — the webview is opaque there and the
+/// window-config colour already covers its own resize gutter.
+#[cfg(not(target_os = "macos"))]
+pub fn apply(_window: &tauri::WebviewWindow, _r: u8, _g: u8, _b: u8) {}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -19,6 +19,18 @@ use serde::{Deserialize, Serialize};
 use tauri::{ipc::Channel, AppHandle, Emitter, Manager, State};
 use url::Url;
 
+// ─────────────────────────── native chrome ───────────────────────────
+
+/// Repaint the native window + webview backing to `(r, g, b)` so a live resize
+/// never flashes a mismatched strip at the dragged edge. macOS-only effect (see
+/// `backing::apply`, which pins drawsBackground / underPageBackgroundColor /
+/// NSWindow); a harmless no-op elsewhere. Called from the frontend on every
+/// theme change, alongside Tauri's cross-platform `setBackgroundColor`.
+#[tauri::command]
+pub fn set_native_backing(window: tauri::WebviewWindow, r: u8, g: u8, b: u8) {
+    crate::backing::apply(&window, r, g, b);
+}
+
 // ─────────────────────────── folders ───────────────────────────
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -147,7 +147,11 @@ pub fn run() {
                     match dark_shade.as_deref() {
                         Some("dimmer") => (0x1C, 0x17, 0x15),
                         Some("black") => (0x15, 0x10, 0x0F),
-                        _ => (0x25, 0x20, 0x1F),
+                        // #1D1E1F — the shipped dark `--reader` (styles.css) and
+                        // the frontend's DARK_BACKING. Keep these in sync so the
+                        // cold-start frame matches before the frontend re-asserts
+                        // `set_native_backing`.
+                        _ => (0x1D, 0x1E, 0x1F),
                     }
                 } else {
                     (0xFB, 0xF9, 0xF3)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@
 // `crate::ingestion`, etc. unchanged.
 pub use papr_core::{ai, db, error, extraction, ingestion, models, opml, sanitize, sync};
 
+mod backing;
 mod commands;
 mod notify;
 mod page_view;
@@ -128,55 +129,31 @@ pub fn run() {
                 }
             }
 
-            // ── Kill the WKWebview's opaque white backing (macOS) ─────
-            // On macOS wry creates the WKWebview isOpaque=true / drawsBackground
-            // =true (a solid WHITE backing) and only turns that off under its
-            // `transparent` cargo feature — which we don't enable. So during a
-            // live window resize the webview's renderer lags the new size and
-            // the freshly-exposed strip shows that white backing. No CSS, html
-            // background, or NSWindow colour can cover it: the opaque webview
-            // layer composites ON TOP of the page. The only fix is to make the
-            // webview non-opaque so the (themed) NSWindow background shows
-            // through that strip instead. See tauri-apps/tauri#14288.
-            #[cfg(target_os = "macos")]
-            if let Some(win) = app.get_webview_window("main") {
-                let _ = win.with_webview(|webview| {
-                    use objc2::msg_send;
-                    use objc2::runtime::AnyObject;
-                    use objc2_foundation::{NSNumber, NSString};
-                    let wk = webview.inner() as *mut AnyObject;
-                    if !wk.is_null() {
-                        unsafe {
-                            let _: () = msg_send![wk, setOpaque: false];
-                            // `drawsBackground` is a private KVC key on WKWebView
-                            // — the same one wry toggles for transparent windows.
-                            let no = NSNumber::numberWithBool(false);
-                            let key = NSString::from_str("drawsBackground");
-                            let _: () = msg_send![wk, setValue: &*no, forKey: &*key];
-                        }
-                    }
-                });
-            }
-
-            // ── Themed launch background ──────────────────────────────
-            // `tauri.conf.json` hardcodes a light window background, so a
-            // dark-theme user would see a brief light flash in the gap
-            // between window creation and the webview's first paint. Repaint
-            // the window in the saved theme's colour here in `setup` — which
-            // runs before that first frame — so the launch is flash-free.
-            // (The frontend re-asserts this on every theme change.)
-            if theme.as_deref() == Some("dark") {
-                if let Some(win) = app.get_webview_window("main") {
-                    // Match the dark-shade's `--reader` in styles.css / DARK_BACKING
-                    // — the webview is non-opaque, so a resize exposes this colour
-                    // and it must blend with the reader pane, not the darker floor.
-                    let (r, g, b) = match dark_shade.as_deref() {
+            // ── Themed native backing (kills the macOS resize flash) ──
+            // `tauri.conf.json` hardcodes a light window background and wry
+            // leaves the WKWebView painting an opaque white backing (it only
+            // disables that under its `transparent` feature, which we don't
+            // build). So between window creation and the webview's first paint —
+            // and in the strip a live resize exposes — a dark-theme user sees a
+            // white flash. `backing::apply` repaints every native surface that
+            // can show through (drawsBackground / underPageBackgroundColor /
+            // NSWindow). Done here before the first frame; the frontend
+            // re-asserts it on every theme change. See backing.rs / tauri#14288.
+            {
+                let (r, g, b) = if theme.as_deref() == Some("dark") {
+                    // Match the dark-shade's `--reader` in styles.css — the
+                    // exposed strip must blend with the reader pane, not the
+                    // darker floor.
+                    match dark_shade.as_deref() {
                         Some("dimmer") => (0x1C, 0x17, 0x15),
                         Some("black") => (0x15, 0x10, 0x0F),
                         _ => (0x25, 0x20, 0x1F),
-                    };
-                    let _ = win
-                        .set_background_color(Some(tauri::window::Color(r, g, b, 0xFF)));
+                    }
+                } else {
+                    (0xFB, 0xF9, 0xF3)
+                };
+                if let Some(win) = app.get_webview_window("main") {
+                    backing::apply(&win, r, g, b);
                 }
             }
 
@@ -266,6 +243,7 @@ pub fn run() {
             commands::freshrss_status,
             commands::freshrss_sync,
             commands::refresh_tray,
+            commands::set_native_backing,
             commands::take_pending_deep_link,
             commands::list_tags,
             commands::create_tag,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useQueryClient } from "@tanstack/react-query";
+import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
@@ -40,6 +41,13 @@ const ACCENT = {
 // darker `--paper` floor — otherwise the exposed strip flashes a shade darker
 // than the reader content it sits next to. Mirrors `--reader` in styles.css.
 const DARK_BACKING = "#1D1E1F";
+
+// "#RRGGBB" → [r, g, b]. Used to hand the native backing colour to the
+// set_native_backing command, which paints macOS surfaces the JS setters miss.
+function hexRgb(hex: string): [number, number, number] {
+  const n = parseInt(hex.slice(1), 16);
+  return [(n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff];
+}
 
 export default function App() {
   const { t } = useTranslation();
@@ -91,7 +99,7 @@ export default function App() {
     root.style.setProperty("--accent-soft", dark ? a.dSoft : a.soft);
     root.style.setProperty("--accent-ink", dark ? a.dInk : a.ink);
     // Keep the native window backing on the themed reader colour. The webview is
-    // non-opaque on macOS (see lib.rs), so a live resize exposes the NSWindow
+    // non-opaque on macOS (see backing.rs), so a live resize exposes the NSWindow
     // background in the strip the webview hasn't repainted yet — use --reader so
     // that strip blends with the reader pane it sits next to. (On Win/Linux the
     // webview is opaque, so setBackgroundColor here mainly covers their own
@@ -99,6 +107,12 @@ export default function App() {
     const backing = dark ? DARK_BACKING : "#FBF9F3";
     getCurrentWindow().setBackgroundColor(backing).catch(() => {});
     getCurrentWebview().setBackgroundColor(backing).catch(() => {});
+    // macOS only: the calls above can't reach `underPageBackgroundColor`, the
+    // overscroll/resize *gutter* that otherwise stays stuck on the light config
+    // colour and flashes white at a fast-resize edge. set_native_backing pins it
+    // (plus drawsBackground + NSWindow) in one shot; a no-op off macOS.
+    const [r, g, b] = hexRgb(backing);
+    invoke("set_native_backing", { r, g, b }).catch(() => {});
   }, [theme, density]);
 
   // ── dismiss the boot splash once the app shell has mounted ──

--- a/src/styles.css
+++ b/src/styles.css
@@ -11,6 +11,9 @@
   --panel: #FBF9F3;
   --panel-2: #FFFEFA;
   --reader: #FBF9F3;
+  /* Hex mirror of --reader for the root html/body background — see the dark
+     note below: a root-propagated oklch background flashes white on resize. */
+  --resize-backing: #FBF9F3;
 
   --ink: #1A1816;
   --ink-2: #3A3733;
@@ -79,6 +82,11 @@
   --panel: oklch(0.190 0.002 250);  /* #131415 — sidebar, recedes */
   --panel-2: oklch(0.215 0.002 250);/* #19191a — list rows + floating menus */
   --reader: oklch(0.235 0.002 250); /* #1d1e1f — reading surface, lightest */
+  /* Hex mirror of --reader. The root html/body background MUST stay hex (see the
+     --paper note above): a root-propagated oklch viewport background flashes
+     white in the strip WebKit exposes during a live resize. Child elements
+     (.window's gradient, the panes) keep oklch — they're unaffected. */
+  --resize-backing: #1D1E1F;
 
   --ink: oklch(0.930 0.006 50);     /* #ebe7e4 — soft warm white, never #fff */
   --ink-2: oklch(0.800 0.006 48);
@@ -150,13 +158,16 @@ html, body, #root { height: 100%; margin: 0; }
    The panes tile the whole window (fixed sidebar + list + 1fr reader, separated
    by borders not gaps), so this colour is invisible in steady state — it only
    shows in that resize seam. Using `--paper` (#0A0B0C, the near-black floor)
-   made the seam flash black against the lighter panes; `--reader` matches the
-   widest pane (the 1fr reader, where most of the seam is) so the seam blends.
+   made the seam flash black against the lighter panes; `--resize-backing` is the
+   hex mirror of `--reader`, matching the widest pane (the 1fr reader, where most
+   of the seam is) so the seam blends. It MUST be hex, not the oklch `--reader`
+   var: this is the root viewport background, and a root-propagated oklch
+   background flashes white on resize (see the dark `--resize-backing` note).
    (The white half of the resize flash is fixed natively — see backing.rs; this
    is the web-layer half.) Stays a theme var so light/dark both track. */
-html { background: var(--reader); }
+html { background: var(--resize-backing); }
 body {
-  background: var(--reader);
+  background: var(--resize-backing);
   font-family: var(--ui);
   -webkit-font-smoothing: antialiased;
   color: var(--ink);

--- a/src/styles.css
+++ b/src/styles.css
@@ -144,15 +144,19 @@
 
 * { box-sizing: border-box; }
 html, body, #root { height: 100%; margin: 0; }
-/* Keep the document background on the themed paper colour so any strip a
-   resize exposes before `.window` repaints matches. NOTE: this alone does NOT
-   fix the macOS resize flash — the WKWebview is opaque and hides this layer;
-   the real fix is setting the webview's native backing per theme (see the
-   setBackgroundColor calls in App.tsx). A hardcoded dark value here flashed
-   black in the light theme, so it stays var(--paper). */
-html { background: var(--paper); }
+/* Document background = the themed READER colour, NOT the `--paper` floor.
+   During a live window resize the grid's panes lag a frame behind the new
+   viewport size, and whatever the document paints under them shows in that gap.
+   The panes tile the whole window (fixed sidebar + list + 1fr reader, separated
+   by borders not gaps), so this colour is invisible in steady state — it only
+   shows in that resize seam. Using `--paper` (#0A0B0C, the near-black floor)
+   made the seam flash black against the lighter panes; `--reader` matches the
+   widest pane (the 1fr reader, where most of the seam is) so the seam blends.
+   (The white half of the resize flash is fixed natively — see backing.rs; this
+   is the web-layer half.) Stays a theme var so light/dark both track. */
+html { background: var(--reader); }
 body {
-  background: var(--paper);
+  background: var(--reader);
   font-family: var(--ui);
   -webkit-font-smoothing: antialiased;
   color: var(--ink);
@@ -170,13 +174,34 @@ button { font-family: inherit; }
 .reader-scroll,
 .settings-scroll {
   scrollbar-width: thin;
+  /* Isolate each pane's layout + paint from the others. During a live window
+     resize this caps the reflow/raster WebKit must redo to the pane that
+     actually changed width, so content catches up to the frame faster and the
+     dark "lag band" at the resized edge is shorter. Safe here: these are all
+     `overflow-y: auto` scroll containers that already clip, and floating menus
+     /dialogs are portaled to <body>, outside them. (The white-flash half of the
+     resize artifact is fixed natively — see backing.rs.) */
+  contain: layout paint;
 }
 
 /* ====== Window ====== */
 .window {
   width: 100vw;
   height: 100vh;
-  background: var(--paper);
+  /* The resize seam (see html/body note) shows THIS background wherever the
+     panes lag a frame behind a live resize. A flat colour can only match one
+     pane; the seam spans all three. So paint a hard-stop horizontal gradient
+     aligned to the exact column boundaries (`--col-sidebar` / `--col-list`,
+     kept live from the drag handles), so the seam under each column matches
+     that column's pane: --panel | --panel-2 | --reader. Invisible in steady
+     state (panes cover it); only the resize seam reveals it. */
+  background: linear-gradient(
+    to right,
+    var(--panel) var(--col-sidebar),
+    var(--panel-2) var(--col-sidebar),
+    var(--panel-2) calc(var(--col-sidebar) + var(--col-list)),
+    var(--reader) calc(var(--col-sidebar) + var(--col-list))
+  );
   color: var(--ink);
   display: grid;
   grid-template-columns: var(--col-sidebar) var(--col-list) 1fr;


### PR DESCRIPTION
## Problem

In the **dark theme**, a fast window resize flashed twice at the freshly exposed edge:

1. **White flash** on the newly revealed edge.
2. A **dark lag band** as content trailed the window.

These are macOS WebView **compositor** artifacts — the strip is shown *before* any framework re-renders, so React render cost is not involved (SolidJS would behave identically). The fix is two independent halves.

## Fix

### Native — the white half (`src-tauri/src/backing.rs`)

wry leaves the WKWebView painting an opaque **white** backing unless its `transparent` feature is enabled (we don't build it). Our window is `titleBarStyle: "Overlay"` (macOS `fullSizeContentView`), which stacks opaque container `NSView`s between the webview and the `NSWindow`. The textbook `drawsBackground=NO` + themed `NSWindow` colour — enough for a *default* window — never reaches those layers.

New `backing::apply` pins **every** surface the resize strip can expose to the themed colour:

- `drawsBackground = NO` + `setOpaque = NO`
- `underPageBackgroundColor` (the overscroll / resize gutter, macOS 12+)
- the `CALayer` of the webview **and every ancestor up to — not past — the window's `contentView`**
- `NSWindow.backgroundColor`

Applied in `setup()` before the first frame and re-asserted from the frontend on each theme change via a new `set_native_backing` command.

### CSS — the dark half (`src/styles.css`)

The seam the panes leave during a live resize paints the document background. It was `--paper` (the near-black floor), which flashed dark against the lighter panes. `.window` now paints a **hard-stop horizontal gradient** aligned to the live column boundaries (`--col-sidebar` / `--col-list`), so the seam under each column matches that column's pane: `--panel | --panel-2 | --reader`. Invisible in steady state (panes cover it); `html`/`body` fall back to `--reader`. Pane scroll containers also get `contain: layout paint` to shorten the seam.

## Testing

- Verified by hand on macOS: white flash gone; resize seam blends per-column in both dark and light themes.
- `cargo build` + `cargo clippy` clean; `tsc --noEmit` clean; `vitest` 70/70 pass.

## Notes

- New macOS-only deps `objc2-web-kit` / `objc2-app-kit` (already in the tree via tauri/wry, no new downloads).
- Off-macOS, `backing::apply` and `set_native_backing` are no-ops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS windows now refresh their native backing colors in real time to better match the current app theme.
  * Theme changes are applied more consistently across the main window and web content.
* **Bug Fixes**
  * Reduced black/mismatched “edge flash” during live window resizing on macOS.
  * Improved visual continuity between panes so resize seams are less noticeable.
* **Style**
  * Updated resize-gap background and added better paint containment to minimize visible lag during resizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->