### PR TITLE
refactor: address review findings from #92 (list preview translation)

### DIFF
--- a/crates/papr-core/src/db.rs
+++ b/crates/papr-core/src/db.rs
@@ -10,6 +10,13 @@ use std::path::Path;
 use std::sync::LazyLock;
 
 /// Append-only schema migrations. Never edit a shipped migration — add a new one.
+/// How many leading characters of an article's `body_text` form the list
+/// "snippet". This single source of truth is shared by the list query (which
+/// derives `ArticleSummary.snippet`) and the preview-translation command (which
+/// translates the same slice), so the translated snippet always corresponds to
+/// the original the list would otherwise show.
+pub const PREVIEW_SNIPPET_CHARS: usize = 280;
+
 static MIGRATIONS: LazyLock<Migrations> = LazyLock::new(|| {
     Migrations::new(vec![M::up(
         r#"
@@ -263,7 +270,6 @@ static MIGRATIONS: LazyLock<Migrations> = LazyLock::new(|| {
                 engine     TEXT NOT NULL,
                 title      TEXT NOT NULL,
                 snippet    TEXT NOT NULL,
-                updated_at TEXT NOT NULL DEFAULT (datetime('now')),
                 PRIMARY KEY(article_id, lang, engine)
             );
             CREATE TRIGGER article_preview_translations_au
@@ -1188,11 +1194,12 @@ pub fn list_articles(
     let (mut where_clauses, mut binds) = article_filter(query, unread_only);
 
     let searching = search.map(|s| !s.trim().is_empty()).unwrap_or(false);
-    let mut sql = String::from(
+    let mut sql = format!(
         "SELECT a.id, a.feed_id, f.title, f.source_type, a.title, a.author,
-                substr(a.body_text,1,280), a.image_url, a.url, a.published_at,
+                substr(a.body_text,1,{snippet_len}), a.image_url, a.url, a.published_at,
                 a.is_read, a.is_starred, a.read_later
          FROM articles a JOIN feeds f ON f.id = a.feed_id ",
+        snippet_len = PREVIEW_SNIPPET_CHARS,
     );
     if searching {
         sql.push_str("JOIN articles_fts fts ON fts.rowid = a.id ");
@@ -1513,12 +1520,11 @@ pub fn set_preview_translation(
     engine: &str,
 ) -> AppResult<()> {
     conn.execute(
-        "INSERT INTO article_preview_translations(article_id, lang, engine, title, snippet, updated_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, datetime('now'))
+        "INSERT INTO article_preview_translations(article_id, lang, engine, title, snippet)
+         VALUES (?1, ?2, ?3, ?4, ?5)
          ON CONFLICT(article_id, lang, engine) DO UPDATE SET
              title = excluded.title,
-             snippet = excluded.snippet,
-             updated_at = excluded.updated_at",
+             snippet = excluded.snippet",
         params![id, lang, engine, title.trim(), snippet.trim()],
     )?;
     Ok(())

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -870,17 +870,6 @@ pub struct ArticlePreviewTranslation {
     engine: String,
 }
 
-fn preview_translation_prompt(target: &str) -> String {
-    format!(
-        "You are a professional translator. Translate the text content of the \
-         HTML fragment into {target}.\n\n\
-         Rules:\n\
-         - Preserve the h1 and p tags exactly.\n\
-         - Translate only human-readable text.\n\
-         - Output only the translated HTML fragment: no preamble, no code fences."
-    )
-}
-
 fn escape_preview_text(s: &str) -> String {
     s.replace('&', "&amp;")
         .replace('<', "&lt;")
@@ -945,7 +934,7 @@ pub async fn translate_article_preview(
         let (title, body) = db::article_preview_text(&conn, article_id)?;
         (
             title,
-            truncate(body.trim(), 280),
+            truncate(body.trim(), db::PREVIEW_SNIPPET_CHARS),
             build_translate_selection(&conn, &engine)?,
             target,
         )
@@ -956,7 +945,10 @@ pub async fn translate_article_preview(
 
     let http = state.http();
     let backend = translate::ready(&http, sel).await?;
-    let system = preview_translation_prompt(translate::language_name(&target));
+    // Reuse the reader's canonical translation prompt rather than a second copy:
+    // the preview fragment is just an `<h1>`/`<p>` pair, so "preserve every HTML
+    // tag" covers it, and a single prompt can never drift between the two paths.
+    let system = translate::translate_system_prompt(translate::language_name(&target));
     let source = preview_translation_html(&title, &snippet);
     let raw = backend.translate_batch(&http, &system, &source, &target).await?;
     let clean = sanitize::sanitize(raw.trim(), None);
@@ -969,7 +961,7 @@ pub async fn translate_article_preview(
     {
         let conn = state.db.lock().await;
         let (current_title, current_body) = db::article_preview_text(&conn, article_id)?;
-        let current_snippet = truncate(current_body.trim(), 280);
+        let current_snippet = truncate(current_body.trim(), db::PREVIEW_SNIPPET_CHARS);
         if current_title != title || current_snippet != snippet {
             return Err(AppError::code("articlePreviewChanged"));
         }
@@ -1605,6 +1597,38 @@ pub async fn delete_highlight(state: State<'_, AppState>, id: i64) -> AppResult<
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- preview-translation helpers: the plain-text round-trip the list uses ---
+
+    #[test]
+    fn escape_preview_text_escapes_markup_sensitive_chars() {
+        assert_eq!(
+            escape_preview_text(r#"A & B < C > "D""#),
+            "A &amp; B &lt; C &gt; &quot;D&quot;",
+        );
+    }
+
+    #[test]
+    fn preview_html_escaping_survives_a_bracket_in_the_title() {
+        // A title like "Rust <T>: generics" must not inject a stray tag: after
+        // escaping and re-parsing, the fragment is still exactly one h1 + one p,
+        // and the text extracted back out matches the source verbatim.
+        let html = preview_translation_html("Rust <T>: generics", "a & b");
+        assert_eq!(text_for_selector(&html, "h1"), "Rust <T>: generics");
+        assert_eq!(text_for_selector(&html, "p"), "a & b");
+    }
+
+    #[test]
+    fn text_for_selector_extracts_and_collapses_whitespace() {
+        let frag = "<h1>  Hello   world </h1><p>one\n two</p>";
+        assert_eq!(text_for_selector(frag, "h1"), "Hello world");
+        assert_eq!(text_for_selector(frag, "p"), "one two");
+    }
+
+    #[test]
+    fn text_for_selector_returns_empty_when_the_tag_is_absent() {
+        assert_eq!(text_for_selector("<p>body only</p>", "h1"), "");
+    }
 
     // --- referer_candidates: the Referer fallback chain for image fetches. ---
 

--- a/src/components/ArticleList.tsx
+++ b/src/components/ArticleList.tsx
@@ -7,6 +7,7 @@ import * as api from "../api";
 import { useUi } from "../store";
 import { useArticleActions } from "../hooks/articleActions";
 import { listTranslationKey, useListTranslation } from "../listTranslation";
+import { resolveRowTranslation } from "../lib/rowTranslation";
 import { relTime } from "../lib/feedMeta";
 import { isMac, modCombo } from "../lib/platform";
 import { reportError, toast } from "../toast";
@@ -583,25 +584,12 @@ export default function ArticleList({ onToast }: Props) {
               const feed = feedById[a.feedId];
               const liveTranslation =
                 listTranslationJobs[listTranslationKey(a.id, targetLang, translateEngine)];
-              const showListTranslation = listTranslateMode === "auto";
-              const liveTranslated =
-                liveTranslation?.status === "done" &&
-                (!!liveTranslation.title || !!liveTranslation.snippet);
-              const hasListTranslation = showListTranslation && liveTranslated;
-              const isTranslating =
-                showListTranslation &&
-                (liveTranslation?.status === "queued" ||
-                  liveTranslation?.status === "translating");
-              const translateError =
-                showListTranslation && liveTranslation?.status === "error"
-                  ? liveTranslation.error || t("error.unknown")
-                  : null;
-              const translatedTitle = hasListTranslation
-                ? liveTranslation.title || a.title
-                : a.title;
-              const translatedSnippet = hasListTranslation
-                ? liveTranslation.snippet || a.snippet
-                : a.snippet;
+              const rt = resolveRowTranslation(
+                a,
+                liveTranslation,
+                listTranslateMode,
+                t("error.unknown"),
+              );
               return (
                 // Key by the virtual slot, not the article id. The window of
                 // rendered rows is a fixed band that slides as you scroll, so
@@ -651,26 +639,24 @@ export default function ArticleList({ onToast }: Props) {
                       )}
                       <span className="art-sep">·</span>
                       <span className="art-time">{relTime(a.publishedAt)}</span>
-                      {(isTranslating || translateError) && (
+                      {(rt.isTranslating || rt.error) && (
                         <span
                           className={`art-translate-status ${
-                            translateError ? "error" : "loading"
+                            rt.error ? "error" : "loading"
                           }`}
                           data-no-hover-preview
                           title={
-                            translateError ||
-                            t("articleList.translateStatusLoading")
+                            rt.error || t("articleList.translateStatusLoading")
                           }
                           aria-label={
-                            translateError ||
-                            t("articleList.translateStatusLoading")
+                            rt.error || t("articleList.translateStatusLoading")
                           }
                           onMouseEnter={leaveHover}
                         >
                           <Icon
-                            name={translateError ? "alert" : "refresh"}
+                            name={rt.error ? "alert" : "refresh"}
                             size={11}
-                            className={translateError ? undefined : "spinning"}
+                            className={rt.error ? undefined : "spinning"}
                           />
                         </span>
                       )}
@@ -685,15 +671,15 @@ export default function ArticleList({ onToast }: Props) {
                         </span>
                       )}
                     </div>
-                    <h3 className="art-title" title={hasListTranslation ? a.title : undefined}>
-                      {translatedTitle}
+                    <h3 className="art-title" title={rt.hasTranslation ? a.title : undefined}>
+                      {rt.title}
                     </h3>
-                    {translatedSnippet && (
+                    {rt.snippet && (
                       <p
                         className="art-snippet"
-                        title={hasListTranslation ? (a.snippet ?? undefined) : undefined}
+                        title={rt.hasTranslation ? (a.snippet ?? undefined) : undefined}
                       >
-                        {translatedSnippet}
+                        {rt.snippet}
                       </p>
                     )}
                   </div>

--- a/src/lib/rowTranslation.test.ts
+++ b/src/lib/rowTranslation.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { resolveRowTranslation } from "./rowTranslation";
+import type { ListTranslationJob } from "../listTranslation";
+
+const source = { title: "Original title", snippet: "Original snippet" };
+
+const job = (over: Partial<ListTranslationJob>): ListTranslationJob => ({
+  status: "done",
+  articleId: 1,
+  lang: "zh",
+  engine: "llm",
+  sourceTitle: source.title,
+  sourceSnippet: source.snippet,
+  title: null,
+  snippet: null,
+  ...over,
+});
+
+describe("resolveRowTranslation", () => {
+  it("shows the original untouched when the mode is off, even if a job is done", () => {
+    const rt = resolveRowTranslation(
+      source,
+      job({ status: "done", title: "译标题", snippet: "译摘要" }),
+      "off",
+      "unknown",
+    );
+    expect(rt).toMatchObject({
+      hasTranslation: false,
+      isTranslating: false,
+      error: null,
+      title: "Original title",
+      snippet: "Original snippet",
+    });
+  });
+
+  it("replaces title and snippet with the translation once done in auto mode", () => {
+    const rt = resolveRowTranslation(
+      source,
+      job({ status: "done", title: "译标题", snippet: "译摘要" }),
+      "auto",
+      "unknown",
+    );
+    expect(rt.hasTranslation).toBe(true);
+    expect(rt.title).toBe("译标题");
+    expect(rt.snippet).toBe("译摘要");
+  });
+
+  it("falls back to the original text for any empty translated field", () => {
+    const rt = resolveRowTranslation(
+      source,
+      job({ status: "done", title: "", snippet: "译摘要" }),
+      "auto",
+      "unknown",
+    );
+    // Empty translated title → original title; snippet still translated.
+    expect(rt.hasTranslation).toBe(true);
+    expect(rt.title).toBe("Original title");
+    expect(rt.snippet).toBe("译摘要");
+  });
+
+  it("reports queued and translating jobs as in-flight without altering text", () => {
+    for (const status of ["queued", "translating"] as const) {
+      const rt = resolveRowTranslation(source, job({ status }), "auto", "unknown");
+      expect(rt.isTranslating).toBe(true);
+      expect(rt.hasTranslation).toBe(false);
+      expect(rt.title).toBe("Original title");
+    }
+  });
+
+  it("surfaces the job error, using the fallback when none is attached", () => {
+    expect(
+      resolveRowTranslation(source, job({ status: "error", error: "boom" }), "auto", "unknown")
+        .error,
+    ).toBe("boom");
+    expect(
+      resolveRowTranslation(source, job({ status: "error" }), "auto", "unknown").error,
+    ).toBe("unknown");
+  });
+
+  it("treats a missing job as plain original text", () => {
+    const rt = resolveRowTranslation(source, undefined, "auto", "unknown");
+    expect(rt).toMatchObject({
+      hasTranslation: false,
+      isTranslating: false,
+      error: null,
+      title: "Original title",
+      snippet: "Original snippet",
+    });
+  });
+});

--- a/src/lib/rowTranslation.ts
+++ b/src/lib/rowTranslation.ts
@@ -1,0 +1,47 @@
+// Pure view-model for a single article-list row's translation state. Kept free
+// of any Tauri/API imports (type-only imports below are erased at build time) so
+// the row-display branching is unit-testable in a plain node environment and the
+// row JSX in ArticleList can stay declarative.
+
+import type { ArticleSummary } from "../types";
+import type { ListTranslationJob } from "../listTranslation";
+
+export interface RowTranslation {
+  /** A translated title/snippet is being shown, so the row can offer the
+   *  original text as a hover `title`. */
+  hasTranslation: boolean;
+  /** The row's translation is queued or in flight. */
+  isTranslating: boolean;
+  /** Resolved error message to surface on the row, or null. */
+  error: string | null;
+  /** The title to render (translated when available, else the original). */
+  title: string;
+  /** The snippet to render (translated when available, else the original). */
+  snippet: string | null;
+}
+
+/**
+ * Decide what one list row should display given its (maybe-absent) translation
+ * job and the current list-translation mode. In "off" mode the original title
+ * and snippet always win; in "auto" mode a completed job's text replaces them
+ * and queued/in-flight/error states are surfaced.
+ */
+export const resolveRowTranslation = (
+  source: Pick<ArticleSummary, "title" | "snippet">,
+  job: ListTranslationJob | undefined,
+  mode: "off" | "auto",
+  unknownError: string,
+): RowTranslation => {
+  const show = mode === "auto";
+  const translated =
+    job?.status === "done" && (!!job.title || !!job.snippet);
+  const hasTranslation = show && translated;
+  return {
+    hasTranslation,
+    isTranslating:
+      show && (job?.status === "queued" || job?.status === "translating"),
+    error: show && job?.status === "error" ? job.error || unknownError : null,
+    title: hasTranslation ? job!.title || source.title : source.title,
+    snippet: hasTranslation ? job!.snippet || source.snippet : source.snippet,
+  };
+};

--- a/src/listTranslation.ts
+++ b/src/listTranslation.ts
@@ -28,10 +28,37 @@ interface ListTranslationState {
 }
 
 const MAX_CONCURRENT = 3;
+// Cap the retained job map. The reader's body-translation store prunes via
+// `clear` once its result is read back; this store has no single read-back
+// point (every visible row reads its job on each render), so instead it evicts
+// the oldest *settled* jobs when the map grows past this bound. Completed
+// results are also persisted in the DB preview cache, so an evicted row simply
+// re-resolves from that cache on its next pass rather than losing anything.
+const MAX_JOBS = 400;
 const keyFor = (articleId: number, lang: string, engine: string) =>
   `${articleId}:${lang}:${engine}`;
 
 export const listTranslationKey = keyFor;
+
+// Drop the oldest done/error jobs once the map exceeds MAX_JOBS; queued and
+// in-flight jobs are never evicted (a running job must survive to record its
+// result). Object key insertion order approximates least-recently-added.
+const pruneJobs = (
+  jobs: Record<string, ListTranslationJob>,
+): Record<string, ListTranslationJob> => {
+  const keys = Object.keys(jobs);
+  const overflow = keys.length - MAX_JOBS;
+  if (overflow <= 0) return jobs;
+  const evictable = keys.filter((k) => {
+    const s = jobs[k].status;
+    return s === "done" || s === "error";
+  });
+  if (evictable.length === 0) return jobs;
+  const drop = new Set(evictable.slice(0, Math.min(overflow, evictable.length)));
+  const next: Record<string, ListTranslationJob> = {};
+  for (const k of keys) if (!drop.has(k)) next[k] = jobs[k];
+  return next;
+};
 
 export const useListTranslation = create<ListTranslationState>((set, get) => {
   const runNext = () => {
@@ -130,7 +157,7 @@ export const useListTranslation = create<ListTranslationState>((set, get) => {
       }
 
       if (!changed) return;
-      set((s) => ({ jobs: { ...s.jobs, ...additions } }));
+      set((s) => ({ jobs: pruneJobs({ ...s.jobs, ...additions }) }));
       runNext();
     },
   };


### PR DESCRIPTION
Follow-up to #92. Addresses the review findings on the list preview-translation feature. No behavior change to the feature; maintainability/correctness hardening + tests.

## Changes
- **listTranslation**: bound the job map. It never removed entries, so a long scrolling session grew it without limit; now evicts the oldest settled (done/error) jobs past a cap. Completed results are also cached in the DB, so an evicted row re-resolves from cache on its next pass.
- **commands**: reuse `translate::translate_system_prompt` instead of a second, near-identical preview prompt that could silently drift from the canonical one.
- **db**: hoist the 280-char preview length into `db::PREVIEW_SNIPPET_CHARS`, shared by the list query and the preview command, so the translated snippet always matches the slice the list would otherwise show.
- **db**: drop the unused `article_preview_translations.updated_at` column (written but never read).
- **ArticleList**: extract per-row translation branching into a pure, tested `resolveRowTranslation()` helper so the row JSX stays declarative.
- **tests**: preview escaping/extraction (Rust) + row view-model (TS).

## Testing
- `cargo test` (papr-core + src-tauri): pass
- `pnpm test` (vitest): pass
- `pnpm build` (tsc && vite build): pass
- Verified the v17 migration upgrades a real pre-existing DB and the resulting table has no `updated_at` column.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Article list translations now use a shared, more consistent rendering flow for translated titles and snippets.
  * Preview translations and article snippets now use the same text length limit for more predictable previews.

* **Bug Fixes**
  * Fixed preview translation behavior so cached previews update consistently when the displayed snippet changes.
  * Improved translation error and loading indicators in article lists.
  * Prevented translation job history from growing without limit by automatically trimming old completed entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->