### PR TITLE
chore(release): v0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3445,7 +3445,7 @@ dependencies = [
 
 [[package]]
 name = "papr"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "ammonia",
  "anyhow",
@@ -3488,7 +3488,7 @@ dependencies = [
 
 [[package]]
 name = "papr-cli"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "clap",
@@ -3502,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "papr-core"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/crates/papr-cli/Cargo.toml
+++ b/crates/papr-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "papr-cli"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "papr — an agent-facing CLI over your Papr RSS feeds: read, search, triage and refresh from the shell."
 

--- a/crates/papr-core/Cargo.toml
+++ b/crates/papr-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "papr-core"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Papr's UI-free core: SQLite data layer, feed ingestion, and content sanitization. Shared by the desktop app and the agent CLI."
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "papr",
   "private": true,
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "papr"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "papr"
-version = "0.12.0"
+version = "0.13.0"
 description = "Papr — a modern RSS reader"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Papr",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "identifier": "com.thomas.papr",
   "mainBinaryName": "papr-desktop",
   "build": {


### PR DESCRIPTION
Release **v0.13.0**.

## Included since v0.12.0
- feat: list preview translation — viewport-driven auto-translate for article-list titles/snippets (#92)
- refactor: address review findings for list preview translation (#94)
- fix: eliminate dark-theme window resize flash on macOS (#88)
- docs: update README screenshot (#84)

Version bumped across `package.json`, `tauri.conf.json`, the three crate manifests, and both `Cargo.lock` files (both verified `--locked`-consistent). Tagging `v0.13.0` after merge triggers `release.yml` (macOS/Linux builds + GitHub Release + Homebrew tap).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app and related packages to version **0.13.0**.
  * Kept configuration and dependency settings unchanged aside from the version update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->