### PR TITLE
chore(release): v0.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3445,7 +3445,7 @@ dependencies = [
 
 [[package]]
 name = "papr"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "ammonia",
  "anyhow",
@@ -3488,7 +3488,7 @@ dependencies = [
 
 [[package]]
 name = "papr-cli"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "chrono",
  "clap",
@@ -3502,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "papr-core"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/crates/papr-cli/Cargo.toml
+++ b/crates/papr-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "papr-cli"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 description = "papr — an agent-facing CLI over your Papr RSS feeds: read, search, triage and refresh from the shell."
 

--- a/crates/papr-core/Cargo.toml
+++ b/crates/papr-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "papr-core"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 description = "Papr's UI-free core: SQLite data layer, feed ingestion, and content sanitization. Shared by the desktop app and the agent CLI."
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "papr",
   "private": true,
-  "version": "0.13.0",
+  "version": "0.13.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "papr"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "papr"
-version = "0.13.0"
+version = "0.13.1"
 description = "Papr — a modern RSS reader"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Papr",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "identifier": "com.thomas.papr",
   "mainBinaryName": "papr-desktop",
   "build": {


### PR DESCRIPTION
Patch release bumping all manifests and lockfiles to v0.13.1.

Ships the #98 fix (#100): retention-purged articles from full-archive feeds (e.g. Hugo `index.xml`) no longer re-appear as unread on the next refresh, via an `article_tombstones` table.

The `v0.13.1` tag has already been pushed and the release build is running.