### PR TITLE
fix: suppress redundant, unconstrained reader hero image

### DIFF
--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -54,6 +54,31 @@ function bodyPlainText(html: string): string {
   return new DOMParser().parseFromString(html, "text/html").body.textContent ?? "";
 }
 
+/** True when the body opens with its own visual media (image / video / iframe)
+ *  before any real text. Such an article already leads with a strong visual, so
+ *  prepending the list-thumbnail hero on top of it just shows a second, often
+ *  unrelated image — the exact complaint in issue #97, where the body starts
+ *  with a `<video>` cover while the feed's `media:thumbnail` is a different png.
+ *  Walking in document order (media element before the first non-whitespace text
+ *  node) is what the plain `body.includes(imageUrl)` guard can't catch, since
+ *  the hero image and the body's lead media are distinct URLs here. */
+function bodyLeadsWithMedia(html: string): boolean {
+  if (!html) return false;
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  const walker = doc.createTreeWalker(
+    doc.body,
+    NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT,
+  );
+  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      if ((node.textContent ?? "").trim().length > 0) return false;
+    } else if (node instanceof Element) {
+      if (["IMG", "VIDEO", "IFRAME", "PICTURE"].includes(node.tagName)) return true;
+    }
+  }
+  return false;
+}
+
 /** CJK ideographs + Japanese kana + Korean Hangul — scripts read by the
  *  character, not the whitespace-delimited word. */
 const CJK_CHAR = /[぀-ヿ㐀-鿿가-힯豈-﫿]/u;
@@ -472,6 +497,9 @@ export default function Reader({ onToast }: Props) {
       (translating ? `<p><em>${t("reader.translating")}</em></p>` : baseBody)
     : baseBody;
   const displayBody = proxiedBody?.source === body ? proxiedBody.html : body;
+  // Whether the body already opens with its own image/video — if so, the hero
+  // thumbnail is suppressed to avoid a redundant top image (issue #97).
+  const leadsWithMedia = useMemo(() => bodyLeadsWithMedia(baseBody), [baseBody]);
 
   // For hosts that require a Referer (notably 少数派's image CDN), proxy image
   // URLs before injecting the HTML. This avoids relying on WKWebView's image
@@ -944,8 +972,13 @@ export default function Reader({ onToast }: Props) {
             !heroBroken &&
             // Skip the hero when the body already embeds the same image, so
             // feeds that repeat their lead image don't show it twice.
-            !body.includes(a.imageUrl) && (
+            !body.includes(a.imageUrl) &&
+            // Also skip it when the body opens with its own image/video — the
+            // article already leads with a visual, so a separate thumbnail on
+            // top would just be a redundant (often mismatched) image (#97).
+            !leadsWithMedia && (
               <img
+                className="reader-hero"
                 src={heroDataUrl ?? a.imageUrl}
                 alt=""
                 // The original URL when src is a recovered data: URL, so the

--- a/src/styles.css
+++ b/src/styles.css
@@ -2057,6 +2057,17 @@ button { font-family: inherit; }
 }
 
 /* rendered article images */
+/* Reader hero (the list-thumbnail shown above the body). It lives on
+   `.reader-content`, not inside `.article-body`, so the `.article-body img`
+   sizing below does not reach it — without its own constraint a large source
+   image renders at natural size and overflows the column (issue #97). */
+.reader-hero {
+  max-width: 100%;
+  height: auto;
+  border-radius: 8px;
+  margin: 0 0 1.2em;
+  display: block;
+}
 .article-body img {
   max-width: 100%;
   height: auto;


### PR DESCRIPTION
Fixes #97.

Some articles show an unexpected, abnormally large image at the top of the reader (reported example: https://weekly.tw93.fun/posts/272/). Two independent problems stack:

## 1. Abnormal size (CSS)

The reader hero `<img>` is rendered as a direct child of `.reader-content`, **not** inside `.article-body` (the `dangerouslySetInnerHTML` container). The only image-sizing rule, `.article-body img { max-width: 100% }`, therefore never applied to it. A large source image (e.g. a 1291px-wide PNG) rendered at natural size and overflowed the reading column — visible only for images wider than the column, which is why it looked intermittent.

Fix: give the hero its own `.reader-hero` rule with `max-width: 100%`.

## 2. Redundant image

For this feed the article body opens with a `<video>` cover, while the feed's `media:thumbnail` is a *different* image (`8dIM0035.png`). Papr reuses `image_url` (the list-card thumbnail) as a reader hero and prepends it, so the reader shows a second, unrelated image on top of the video.

The existing guard `!body.includes(a.imageUrl)` only skips the hero when the body embeds the *same* URL, so it can't catch this (the URLs differ).

Fix: add `bodyLeadsWithMedia()` — walk the body in document order and, if the first visual element (`img`/`video`/`iframe`/`picture`) precedes any non-whitespace text, treat the article as already leading with a visual and skip the hero. Computed from `baseBody` so it stays stable while a translation is in flight.

## Testing

- `tsc --noEmit` clean; existing vitest suite (76 tests) passes.
- The helper is DOM-dependent and lives in a component file, which this repo deliberately excludes from the node-based test env, so it has no unit test. Recommend a quick in-app visual check against the tw93 weekly feed: the top image should be gone and any remaining hero constrained to the column width.