### PR TITLE
fix: reconcile FreshRSS read state for the whole library, not the last 1000

### DIFF
--- a/crates/papr-core/src/db.rs
+++ b/crates/papr-core/src/db.rs
@@ -2327,6 +2327,78 @@ pub fn set_sync_state(
     Ok(())
 }
 
+/// Resolve a set of feed URLs to the ids of the local feeds that carry them,
+/// skipping any URL the local DB doesn't track. Used to scope a sync
+/// reconciliation to the feeds the server actually knows about.
+pub fn feed_ids_by_urls(
+    conn: &Connection,
+    urls: &std::collections::HashSet<String>,
+) -> AppResult<Vec<i64>> {
+    let mut ids = Vec::with_capacity(urls.len());
+    for url in urls {
+        if let Some(id) = find_feed_by_url(conn, url)? {
+            ids.push(id);
+        }
+    }
+    Ok(ids)
+}
+
+/// Reconcile local read/starred state against the server's authoritative unread
+/// + starred URL sets, for every article under one of `feed_ids`. An article is
+/// marked read unless its URL is in `unread_urls`, and starred iff its URL is in
+/// `starred_urls` — so the server's read state wins even for the long tail of
+/// items a pull of only the recent unread set never enumerates (issue #96).
+///
+/// Articles carrying an un-pushed local edit (in `sync_queue`) are skipped, so a
+/// pull never clobbers a change still waiting to be sent. Only rows whose state
+/// actually changes are written. Returns the number of articles changed.
+pub fn reconcile_sync_state(
+    conn: &Connection,
+    feed_ids: &[i64],
+    unread_urls: &std::collections::HashSet<String>,
+    starred_urls: &std::collections::HashSet<String>,
+) -> AppResult<usize> {
+    let pending: std::collections::HashSet<i64> =
+        pending_sync_article_ids(conn)?.into_iter().collect();
+    let tx = conn.unchecked_transaction()?;
+    let mut changed: Vec<(i64, bool, bool)> = Vec::new();
+    {
+        let mut sel = tx.prepare(
+            "SELECT id, url, is_read, is_starred FROM articles
+             WHERE feed_id = ?1 AND url IS NOT NULL",
+        )?;
+        for &fid in feed_ids {
+            let rows = sel.query_map(params![fid], |r| {
+                Ok((
+                    r.get::<_, i64>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, bool>(2)?,
+                    r.get::<_, bool>(3)?,
+                ))
+            })?;
+            for row in rows {
+                let (id, url, cur_read, cur_starred) = row?;
+                if pending.contains(&id) {
+                    continue;
+                }
+                let read = !unread_urls.contains(&url);
+                let starred = starred_urls.contains(&url);
+                if read != cur_read || starred != cur_starred {
+                    changed.push((id, read, starred));
+                }
+            }
+        }
+    }
+    for (id, read, starred) in &changed {
+        tx.execute(
+            "UPDATE articles SET is_read = ?2, is_starred = ?3 WHERE id = ?1",
+            params![id, read, starred],
+        )?;
+    }
+    tx.commit()?;
+    Ok(changed.len())
+}
+
 /// Queue a local read/starred change to push on the next sync.
 pub fn enqueue_sync(
     conn: &Connection,
@@ -3330,6 +3402,75 @@ mod tests {
             .query_row("SELECT count(*) FROM sync_queue", [], |r| r.get(0))
             .unwrap();
         assert_eq!(queued, 0);
+    }
+
+    // ── sync state reconciliation (issue #96) ────────────────────────
+
+    #[test]
+    fn reconcile_marks_tail_read_and_scopes_to_server_feeds() {
+        let (conn, _aid) = test_db();
+        let feed_id: i64 = conn
+            .query_row("SELECT feed_id FROM articles LIMIT 1", [], |r| r.get(0))
+            .unwrap();
+        // Fixture article a1 (guid g1) plus two more in the same server feed —
+        // all start unread, as a raw RSS poll would leave them.
+        seed(&conn, feed_id, "a2", "Two");
+        seed(&conn, feed_id, "a3", "Three");
+        // A local-only feed the server doesn't know about.
+        let local = insert_feed(
+            &conn,
+            "https://local.example/feed.xml",
+            None,
+            "Local",
+            None,
+            SourceType::Rss,
+            None,
+        )
+        .unwrap();
+        seed(&conn, local, "b1", "Local one");
+
+        // Server: only a2 is unread, a3 is starred.
+        let unread: std::collections::HashSet<String> =
+            ["https://example.com/a2".to_string()].into_iter().collect();
+        let starred: std::collections::HashSet<String> =
+            ["https://example.com/a3".to_string()].into_iter().collect();
+
+        let changed = reconcile_sync_state(&conn, &[feed_id], &unread, &starred).unwrap();
+        assert_eq!(changed, 2, "a1 -> read and a3 -> read+starred; a2 unchanged");
+
+        let read = |g: &str| -> bool {
+            conn.query_row("SELECT is_read FROM articles WHERE guid = ?1", [g], |r| r.get(0))
+                .unwrap()
+        };
+        let is_starred = |g: &str| -> bool {
+            conn.query_row("SELECT is_starred FROM articles WHERE guid = ?1", [g], |r| {
+                r.get(0)
+            })
+            .unwrap()
+        };
+        assert!(read("g1"), "tail item not in unread set is marked read");
+        assert!(!read("a2"), "server-unread item stays unread");
+        assert!(read("a3") && is_starred("a3"), "a3 is read and starred");
+        assert!(!read("b1"), "local-only feed is out of scope and untouched");
+    }
+
+    #[test]
+    fn reconcile_skips_pending_local_edits() {
+        let (conn, aid) = test_db();
+        let feed_id: i64 = conn
+            .query_row("SELECT feed_id FROM articles LIMIT 1", [], |r| r.get(0))
+            .unwrap();
+        // User marked a1 unread locally; the change hasn't been pushed yet.
+        enqueue_sync(&conn, aid, "read", false).unwrap();
+        // Server considers a1 read (empty unread set) — but the pending local
+        // edit must win, so nothing changes.
+        let empty = std::collections::HashSet::new();
+        let changed = reconcile_sync_state(&conn, &[feed_id], &empty, &empty).unwrap();
+        assert_eq!(changed, 0, "pending article is skipped");
+        let read: bool = conn
+            .query_row("SELECT is_read FROM articles WHERE id = ?1", [aid], |r| r.get(0))
+            .unwrap();
+        assert!(!read, "a1 keeps its local (unread) state");
     }
 
     // ── retention cleanup ────────────────────────────────────────────

--- a/crates/papr-core/src/sync.rs
+++ b/crates/papr-core/src/sync.rs
@@ -194,12 +194,13 @@ impl SubCat {
 struct Contents {
     #[serde(default)]
     items: Vec<Item>,
+    // Present when the stream has more pages; fed back as `c=` to page on.
+    #[serde(default)]
+    continuation: Option<String>,
 }
 #[derive(Deserialize)]
 struct Item {
     id: String,
-    #[serde(default)]
-    categories: Vec<String>,
     #[serde(default)]
     canonical: Vec<Href>,
     #[serde(default)]
@@ -317,6 +318,65 @@ fn feeds_to_push<'a>(
         .filter(|u| !server.contains(*u))
         .map(String::as_str)
         .collect()
+}
+
+/// A single article the server flags as unread or starred: its item id and the
+/// canonical URL we match local articles on.
+struct RemoteItem {
+    id: String,
+    url: String,
+}
+
+/// Fetch every item of a GReader stream, following `continuation` pages. `xt`,
+/// when set, is an "exclude tag" filter (e.g. exclude read to get only unread).
+///
+/// Paging is capped: the sets we fetch this way (unread, starred) are bounded by
+/// what the user hasn't yet read/has starred — normally a few hundred items — so
+/// `MAX_PAGES` pages of `n=1000` (tens of thousands of items) is a generous
+/// ceiling that also stops a pathological server from looping us forever.
+async fn fetch_stream_items(
+    session: &Session,
+    http: &Client,
+    stream: &str,
+    xt: Option<&str>,
+) -> AppResult<Vec<RemoteItem>> {
+    const PAGE: &str = "1000";
+    const MAX_PAGES: usize = 30;
+    let path = format!("stream/contents/{stream}");
+    let mut out = Vec::new();
+    let mut cont: Option<String> = None;
+    for _ in 0..MAX_PAGES {
+        let mut params: Vec<(&str, &str)> = vec![("output", "json"), ("n", PAGE)];
+        if let Some(xt) = xt {
+            params.push(("xt", xt));
+        }
+        if let Some(c) = cont.as_deref() {
+            params.push(("c", c));
+        }
+        let page: Contents = session
+            .get(http, &path)
+            .query(&params)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        for item in page.items {
+            if let Some(url) = item
+                .canonical
+                .first()
+                .or_else(|| item.alternate.first())
+                .map(|h| h.href.clone())
+            {
+                out.push(RemoteItem { id: item.id, url });
+            }
+        }
+        match page.continuation {
+            Some(c) if !c.is_empty() => cont = Some(c),
+            _ => break,
+        }
+    }
+    Ok(out)
 }
 
 /// Push queued changes, then pull subscriptions and read/starred state.
@@ -450,43 +510,39 @@ pub async fn sync_now(db: &Db, http: &Client) -> AppResult<usize> {
         }
     }
 
-    // 3 ── pull read/starred state for recent items, matched by URL.
-    let contents: Contents = session
-        .get(
-            http,
-            &format!("stream/contents/{READING_LIST}?output=json&n=1000"),
-        )
-        .send()
-        .await?
-        .error_for_status()?
-        .json()
-        .await?;
+    // 3 ── reconcile read/starred state, treating the server as the source of
+    // truth. Papr polls each subscribed feed's raw RSS independently and marks
+    // every fetched item unread, so the local unread counts drift far above the
+    // server's. Rather than pull the (unbounded) full history, fetch just the
+    // server's *unread* and *starred* sets — both small — then mark every other
+    // synced article read. This is what a pure GReader client effectively does,
+    // and it fixes the runaway unread counts of issue #96 where the old
+    // "reconcile the most recent 1000 items" pass never reached the long tail.
+    let unread = fetch_stream_items(&session, http, READING_LIST, Some(READ_TAG)).await?;
+    let starred = fetch_stream_items(&session, http, STARRED_TAG, None).await?;
 
-    let mut reconciled = 0usize;
-    {
+    let unread_urls: std::collections::HashSet<String> =
+        unread.iter().map(|i| i.url.clone()).collect();
+    let starred_urls: std::collections::HashSet<String> =
+        starred.iter().map(|i| i.url.clone()).collect();
+
+    let reconciled = {
         let conn = db.lock().await;
-        // Articles with still-unsent local edits keep their local state; we
-        // only assign their remote id so the next sync can push them.
-        let pending: std::collections::HashSet<i64> =
-            db::pending_sync_article_ids(&conn)?.into_iter().collect();
-        for item in contents.items {
-            let url = item
-                .canonical
-                .first()
-                .or_else(|| item.alternate.first())
-                .map(|h| h.href.clone());
-            let Some(url) = url else { continue };
-            if let Some(aid) = db::article_id_by_url(&conn, &url)? {
+        // Assign remote ids for the items we did fetch, so a later local edit on
+        // one of them has an id to push. (Read articles in the long tail carry
+        // no id until they next appear in an unread/starred response — pushing a
+        // change on those waits, exactly as before this change.)
+        for item in unread.iter().chain(starred.iter()) {
+            if let Some(aid) = db::article_id_by_url(&conn, &item.url)? {
                 db::set_remote_id(&conn, aid, &item.id)?;
-                if !pending.contains(&aid) {
-                    let read = item.categories.iter().any(|c| c == READ_TAG);
-                    let starred = item.categories.iter().any(|c| c == STARRED_TAG);
-                    db::set_sync_state(&conn, aid, read, starred)?;
-                }
-                reconciled += 1;
             }
         }
-    }
+        // Scope the read/starred sweep to feeds the server actually knows about,
+        // so a local-only feed not yet mirrored server-side isn't wrongly marked
+        // all-read. Articles with an un-pushed local edit are left untouched.
+        let server_feed_ids = db::feed_ids_by_urls(&conn, &server_urls)?;
+        db::reconcile_sync_state(&conn, &server_feed_ids, &unread_urls, &starred_urls)?
+    };
     Ok(reconciled)
 }
 


### PR DESCRIPTION
Fixes #96.

## Symptom

After connecting a FreshRSS account, Papr's unread counts run far above the server's. In the report, folders that FreshRSS (and NetNewsWire) show as `52 / 79 / 1 / 155` unread show as `1090 / 101 / 2338 / 1007` in Papr. NetNewsWire matches the server exactly.

## Cause

Papr uses the GReader API to import the subscription list, but then polls each feed's **raw RSS itself** and marks every fetched item unread. Read state was reconciled separately by pulling only `stream/contents/reading-list?n=1000` — the 1000 most recent items — and matching them to local articles by URL.

On any account with more than ~1000 items, the long tail of already-read articles is never in that window, so those locally-polled articles stay unread forever. Small folders (within the 1000-item window) stayed roughly correct; large ones ballooned — exactly the pattern in the screenshots.

## Fix

Invert the reconciliation so the server is the source of truth, the way a pure GReader client works:

1. Fetch only the server's **unread** set (`reading-list` with `xt=…/read`) and **starred** set — both bounded by what the user hasn't read / has starred, normally a few hundred items — paging via `continuation` (capped at 30 pages).
2. Mark **every other** article under a server-known feed **read**. The unbounded read tail is handled by this default instead of being enumerated.

Details:
- `fetch_stream_items` — page a stream with an optional `xt` exclude filter, following `continuation`.
- `db::reconcile_sync_state` — sweep the given feeds' articles: read unless the URL is in the unread set, starred iff in the starred set; skip articles with un-pushed local edits (`sync_queue`); write only rows that actually change.
- `db::feed_ids_by_urls` — scope the sweep to feeds the server knows about, so a local-only feed not yet mirrored server-side isn't wrongly marked all-read.

## Tests

- `reconcile_marks_tail_read_and_scopes_to_server_feeds` — tail item not in the unread set is marked read; a server-unread item stays unread; starred applied; a local-only feed is untouched.
- `reconcile_skips_pending_local_edits` — an article with a queued, un-pushed local change is not clobbered by the pull.
- Full workspace builds; `papr-core` suite passes.

## Notes / caveats

- Reconciliation matches server items to local articles **by URL** (unchanged from before). If a server's canonical URL differs from the RSS-polled URL, that unread item won't match and the local copy would be marked read. This was already the matching basis; the new default direction just makes a mismatch fail toward "read" rather than "unread".
- A read article in the tail carries no remote id until it next appears in an unread/starred response, so a local edit on such an article waits to push — same as before this change.
- Behavioral change verified at the DB layer; end-to-end confirmation against a live FreshRSS account is recommended.