### PR TITLE
fix: preserve article-list scroll position across focus mode

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1459,12 +1459,16 @@ button { font-family: inherit; }
 .hover-preview .hp-meta { margin-top: 10px; font-size: 11px; color: var(--muted); }
 
 /* ====== Focus mode (immersive reader) ====== */
-.window.focus .sidebar,
-.window.focus .list {
-  display: none;
-}
-.window.focus {
-  grid-template-columns: 1fr;
+/* Overlay the reader across the whole window rather than collapsing the grid
+   and `display: none`-ing the list. Hiding the list dropped its scroll to 0 and
+   collapsed the virtual list to zero height, so exiting focus mode lost the
+   user's scroll position (issue #86). Keeping the sidebar + list mounted and
+   measured underneath means exiting restores their exact prior state for free —
+   the reader simply uncovers them. */
+.window.focus .reader {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
 }
 .window.focus .article { max-width: 720px; }
 /* In focus mode the reader is the leftmost pane, so its toolbar must clear


### PR DESCRIPTION
Fixes #86.

## Symptom

Scroll the article list to some position, open an article, enter Focus Mode, then exit — the list jumps away from where it was (back to the top), losing the browsing position.

## Cause

Focus mode hid the sidebar + list with `display: none` and collapsed the grid to a single reader column. `display: none` **reset the list's `scrollTop` to 0** and collapsed the TanStack virtual list to zero height. On exit the list re-expanded from scratch at offset 0.

Verified live with an on-screen probe: on entering focus mode the saved offset was correct (e.g. `750`), but after exit `scrollTop`/`scrollOffset` were both `0` — the browser had discarded the scroll while the element was `display: none`, and a restore attempted at exit was clamped to 0 because the virtualizer hadn't re-expanded yet.

## Fix

Don't collapse/hide the list at all. In focus mode, overlay the reader across the whole window (`position: absolute; inset: 0; z-index`) while the sidebar + list stay mounted and measured underneath. Exiting focus mode simply uncovers them in their exact prior state — nothing to save or restore.

CSS-only; no JS/virtualizer changes.

## Testing

Verified live in the dev app (before/after via HMR):
- Old CSS: reproduced the jump to the top of the list on exit.
- New CSS: focus mode still shows the immersive full-window reader, and exiting leaves the list exactly where it was scrolled.
- `tsc` + `vite build` clean.