### PR TITLE
chore(release): v0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3445,7 +3445,7 @@ dependencies = [
 
 [[package]]
 name = "papr"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "ammonia",
  "anyhow",
@@ -3488,7 +3488,7 @@ dependencies = [
 
 [[package]]
 name = "papr-cli"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "clap",
@@ -3502,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "papr-core"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/crates/papr-cli/Cargo.toml
+++ b/crates/papr-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "papr-cli"
-version = "0.13.1"
+version = "0.14.0"
 edition = "2021"
 description = "papr — an agent-facing CLI over your Papr RSS feeds: read, search, triage and refresh from the shell."
 

--- a/crates/papr-core/Cargo.toml
+++ b/crates/papr-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "papr-core"
-version = "0.13.1"
+version = "0.14.0"
 edition = "2021"
 description = "Papr's UI-free core: SQLite data layer, feed ingestion, and content sanitization. Shared by the desktop app and the agent CLI."
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "papr",
   "private": true,
-  "version": "0.13.1",
+  "version": "0.14.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "papr"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "papr"
-version = "0.13.1"
+version = "0.14.0"
 description = "Papr — a modern RSS reader"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Papr",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "identifier": "com.thomas.papr",
   "mainBinaryName": "papr-desktop",
   "build": {


### PR DESCRIPTION
Release v0.14.0.

Bumps the version across `package.json`, `tauri.conf.json`, the workspace `Cargo.toml`s, and both `Cargo.lock` files. Tagging `v0.14.0` after this merges triggers the release build.

## Changes since v0.13.1

**Features**
- Full-screen image viewer in the reader with prev/next navigation (#108)
- "System" appearance mode that follows the OS light/dark (#106)
- Split appearance into palette × mode with six themes (#102)

**Fixes**
- Reconcile FreshRSS read state for the whole library, not just the last 1000 items (#105)
- Suppress redundant, unconstrained reader hero image (#104)
- Preserve article-list scroll position across focus mode (#107)
- Dedup guid-less feeds by title + date instead of volatile URL (#103)