### PR TITLE
feat: per-feed and global default article open mode

### DIFF
--- a/crates/papr-core/src/db.rs
+++ b/crates/papr-core/src/db.rs
@@ -296,6 +296,10 @@ static MIGRATIONS: LazyLock<Migrations> = LazyLock::new(|| {
             );
             "#,
         ),
+        // v19 — per-feed open mode (issue #110): 'reader', 'extracted' or
+        // 'web'. NULL (the default) keeps today's behaviour — reader view,
+        // honouring the global auto-extract preference.
+        M::up("ALTER TABLE feeds ADD COLUMN open_mode TEXT;"),
     ])
 });
 
@@ -513,7 +517,7 @@ pub fn list_feeds(conn: &Connection) -> AppResult<Vec<Feed>> {
         "SELECT f.id, f.feed_url, f.site_url, f.title, f.description, f.favicon_url,
                 f.folder_id, f.source_type, f.last_fetched_at, f.fetch_error,
                 (SELECT COUNT(*) FROM articles a WHERE a.feed_id = f.id AND a.is_read = 0),
-                f.refresh_interval_min, f.auto_translate
+                f.refresh_interval_min, f.auto_translate, f.open_mode
          FROM feeds f ORDER BY f.title COLLATE NOCASE",
     )?;
     let rows = stmt
@@ -532,6 +536,7 @@ pub fn list_feeds(conn: &Connection) -> AppResult<Vec<Feed>> {
                 unread_count: r.get(10)?,
                 refresh_interval_min: r.get(11)?,
                 auto_translate: r.get::<_, i64>(12)? != 0,
+                open_mode: r.get(13)?,
             })
         })?
         .collect::<Result<Vec<_>, _>>()?;
@@ -640,6 +645,16 @@ pub fn set_feed_auto_translate(conn: &Connection, id: i64, enabled: bool) -> App
     conn.execute(
         "UPDATE feeds SET auto_translate = ?2 WHERE id = ?1",
         params![id, enabled as i64],
+    )?;
+    Ok(())
+}
+
+/// Set (or clear) a feed's per-feed open mode: `"reader"`, `"extracted"` or
+/// `"web"`. `None` reverts the feed to the default behaviour.
+pub fn set_feed_open_mode(conn: &Connection, id: i64, mode: Option<&str>) -> AppResult<()> {
+    conn.execute(
+        "UPDATE feeds SET open_mode = ?2 WHERE id = ?1",
+        params![id, mode],
     )?;
     Ok(())
 }
@@ -2556,6 +2571,27 @@ mod tests {
         // the 20-minute-old fetch and a 5-minute global, it is due again.
         set_feed_refresh_interval(&conn, feed_id, None).unwrap();
         assert!(!feeds_due_for_refresh(&conn, 5).unwrap().is_empty());
+    }
+
+    #[test]
+    fn open_mode_round_trips_and_clears() {
+        let (conn, _) = test_db();
+        let feed_id: i64 = conn
+            .query_row("SELECT id FROM feeds", [], |r| r.get(0))
+            .unwrap();
+
+        // Fresh feed follows the default.
+        assert_eq!(list_feeds(&conn).unwrap()[0].open_mode, None);
+
+        set_feed_open_mode(&conn, feed_id, Some("web")).unwrap();
+        assert_eq!(
+            list_feeds(&conn).unwrap()[0].open_mode.as_deref(),
+            Some("web")
+        );
+
+        // `None` reverts to the default.
+        set_feed_open_mode(&conn, feed_id, None).unwrap();
+        assert_eq!(list_feeds(&conn).unwrap()[0].open_mode, None);
     }
 
     #[test]

--- a/crates/papr-core/src/models.rs
+++ b/crates/papr-core/src/models.rs
@@ -62,6 +62,11 @@ pub struct Feed {
     /// translation into the configured target language. Off by default, so
     /// existing feeds keep showing the original text.
     pub auto_translate: bool,
+    /// How articles from this feed open in the reader pane: `"reader"` (RSS
+    /// content), `"extracted"` (auto-run full-text extraction) or `"web"`
+    /// (embedded web view of the original page). `None` follows the default
+    /// behaviour (reader view, honouring the global auto-extract preference).
+    pub open_mode: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -211,6 +211,7 @@ pub async fn add_feed(
         unread_count: unread,
         refresh_interval_min: None,
         auto_translate: false,
+        open_mode: None,
     })
 }
 
@@ -301,6 +302,24 @@ pub async fn set_feed_auto_translate(
 ) -> AppResult<()> {
     let conn = state.db.lock().await;
     db::set_feed_auto_translate(&conn, id, enabled)
+}
+
+/// Set a feed's per-feed open mode — how its articles open in the reader pane.
+/// `None` reverts the feed to the default behaviour (reader view, honouring
+/// the global auto-extract preference).
+#[tauri::command]
+pub async fn set_feed_open_mode(
+    state: State<'_, AppState>,
+    id: i64,
+    mode: Option<String>,
+) -> AppResult<()> {
+    if let Some(m) = mode.as_deref() {
+        if !matches!(m, "reader" | "extracted" | "web") {
+            return Err(AppError::other(format!("unknown open mode: {m}")));
+        }
+    }
+    let conn = state.db.lock().await;
+    db::set_feed_open_mode(&conn, id, mode.as_deref())
 }
 
 #[tauri::command]
@@ -1483,6 +1502,7 @@ pub async fn add_newsletter_source(
         unread_count: unread,
         refresh_interval_min: None,
         auto_translate: false,
+        open_mode: None,
     })
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -238,6 +238,7 @@ pub fn run() {
             commands::move_feed,
             commands::set_feed_refresh_interval,
             commands::set_feed_auto_translate,
+            commands::set_feed_open_mode,
             commands::rename_feed,
             commands::refresh_feeds,
             commands::list_articles,

--- a/src/api.ts
+++ b/src/api.ts
@@ -68,6 +68,12 @@ export const setFeedRefreshInterval = (id: number, minutes: number | null) =>
  *  feed translates it into the configured target language straight away. */
 export const setFeedAutoTranslate = (id: number, enabled: boolean) =>
   invoke<void>("set_feed_auto_translate", { id, enabled });
+/** Set a feed's per-feed open mode. `null` reverts to the default behaviour
+ *  (reader view, honouring the global auto-extract preference). */
+export const setFeedOpenMode = (
+  id: number,
+  mode: "reader" | "extracted" | "web" | null,
+) => invoke<void>("set_feed_open_mode", { id, mode });
 
 /** Refresh feeds, reporting progress through the supplied callback. With no
  *  `scope` this refreshes every feed; pass `{ feedId }` for a single feed or

--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -187,13 +187,15 @@ export default function Reader({ onToast }: Props) {
   const markReadOnOpen = useUi((s) => s.prefs.markReadOnOpen);
   const markReadOnScroll = useUi((s) => s.prefs.markReadOnScroll);
   const showReadingTime = useUi((s) => s.prefs.showReadingTime);
-  const autoExtract = useUi((s) => s.prefs.autoExtract);
+  const defaultOpenMode = useUi((s) => s.prefs.defaultOpenMode);
 
   const [scrolled, setScrolled] = useState(false);
-  // Which body to show when an extraction exists follows the "auto-extract"
-  // setting: off (the default) shows the feed's own content and extraction is
-  // opt-in via the toolbar button; on shows the extracted full text.
-  const [showExtracted, setShowExtracted] = useState(autoExtract);
+  // Which body to show when an extraction exists follows the default open
+  // mode: "reader" (the default) shows the feed's own content and extraction
+  // is opt-in via the toolbar button; "extracted" shows the full text.
+  const [showExtracted, setShowExtracted] = useState(
+    defaultOpenMode === "extracted",
+  );
   const [showTranslation, setShowTranslation] = useState(false);
   // Reading vs. the article's original web page, shown in an in-app iframe.
   // Sites that set X-Frame-Options / CSP frame-ancestors refuse to load this
@@ -247,6 +249,16 @@ export default function Reader({ onToast }: Props) {
   const autoTranslateFeed = !!(
     a && feeds.data?.find((f) => f.id === a.feedId)?.autoTranslate
   );
+  // Effective open mode (issue #110): the feed's own setting, falling back to
+  // the global default. `undefined` while the article or feed list is still
+  // loading, so the open-mode/auto-extract effects below don't fire before the
+  // feed's own setting is known.
+  const feedOpenMode =
+    a && feeds.data
+      ? feeds.data.find((f) => f.id === a.feedId)?.openMode ?? null
+      : undefined;
+  const openMode =
+    feedOpenMode === undefined ? undefined : feedOpenMode ?? defaultOpenMode;
 
   const readMinutes = useMemo(() => {
     return estimateReadMinutes(bodyPlainText(a?.extractedHtml || a?.contentHtml || ""));
@@ -256,7 +268,7 @@ export default function Reader({ onToast }: Props) {
 
   // Reset scroll + extraction view on article change.
   useEffect(() => {
-    setShowExtracted(useUi.getState().prefs.autoExtract);
+    setShowExtracted(useUi.getState().prefs.defaultOpenMode === "extracted");
     setShowTranslation(false);
     setViewMode("reader");
     setScrolled(false);
@@ -266,6 +278,19 @@ export default function Reader({ onToast }: Props) {
     scrollMarkedRef.current = null;
     if (scrollRef.current) scrollRef.current.scrollTop = 0;
   }, [id]);
+
+  // Apply the effective open mode once the article (and the feed list) is
+  // available — declared after the reset above so it wins the same commit.
+  // Applied once per article, so the toolbar toggles keep working afterwards
+  // and a feeds refetch never yanks the view back.
+  const openModeAppliedRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (!a || openMode === undefined || openModeAppliedRef.current === a.id)
+      return;
+    openModeAppliedRef.current = a.id;
+    if (openMode === "web" && a.url) setViewMode("web");
+    else setShowExtracted(openMode === "extracted");
+  }, [a, openMode]);
 
   // Drive the native original-page child webview (page_view.rs) while in web
   // mode. It floats above the DOM, so we measure the host rect and keep the
@@ -567,14 +592,14 @@ export default function Reader({ onToast }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, job?.status]);
 
-  // With "auto-extract full text" on, a summary-only feed item is upgraded to
-  // the full page the moment it's opened, so the reader never shows a two-line
-  // stub. Skipped when the feed already carries the whole article, when there
-  // is no source URL to fetch, or once attempted for this article — so a
-  // failed fetch isn't retried on every re-render.
+  // With an "extracted" open mode in effect, a summary-only feed item is
+  // upgraded to the full page the moment it's opened, so the reader never
+  // shows a two-line stub. Skipped when the feed already carries the whole
+  // article, when there is no source URL to fetch, or once attempted for this
+  // article — so a failed fetch isn't retried on every re-render.
   const autoExtractedRef = useRef<number | null>(null);
   useEffect(() => {
-    if (!autoExtract || !a || !a.url || a.extractedHtml) return;
+    if (openMode !== "extracted" || !a || !a.url || a.extractedHtml) return;
     if (autoExtractedRef.current === a.id || extract.isPending) return;
     // Measure the *decoded* text, not the raw markup. A bare `<[^>]+>` tag
     // strip leaves HTML entities intact, so an entity-heavy stub
@@ -583,12 +608,16 @@ export default function Reader({ onToast }: Props) {
     // "complete", leaving the reader showing the very stub auto-extract is
     // meant to replace. `bodyPlainText` decodes entities and drops markup
     // cleanly, the same measurement the reading-time estimate already uses.
-    const plain = bodyPlainText(a.contentHtml || "").trim();
-    if (plain.length >= 800) return; // feed already delivers the full text
+    // An explicit per-feed "extracted" skips the bar entirely — the user asked
+    // for the page's own text even when the feed body looks complete.
+    if (feedOpenMode !== "extracted") {
+      const plain = bodyPlainText(a.contentHtml || "").trim();
+      if (plain.length >= 800) return; // feed already delivers the full text
+    }
     autoExtractedRef.current = a.id;
     extract.mutate(a.id);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [a?.id, a?.extractedHtml, autoExtract]);
+  }, [a?.id, a?.extractedHtml, openMode, feedOpenMode]);
 
   // Per-feed auto-translate: when the article's source feed opts in, translate
   // it into the configured target the moment it opens. Fires once per article

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { getVersion } from "@tauri-apps/api/app";
 import { disable, enable, isEnabled } from "@tauri-apps/plugin-autostart";
 import * as api from "../api";
-import { useUi, READER_BOUNDS } from "../store";
+import { useUi, READER_BOUNDS, type OpenMode } from "../store";
 import { useArticleActions } from "../hooks/articleActions";
 import { useFocusTrap } from "../hooks/useFocusTrap";
 import { LANGUAGES, setLanguage, type Language } from "../i18n";
@@ -738,14 +738,22 @@ function ReadingSection() {
         </Row>
       </div>
       <div className="settings-group">
-        <h3 className="settings-group-title">{t("settings.reading.fulltext")}</h3>
+        <h3 className="settings-group-title">{t("settings.reading.openModeTitle")}</h3>
         <Row
-          label={t("settings.reading.autoExtract")}
-          desc={t("settings.reading.autoExtractDesc")}
+          label={t("settings.reading.defaultOpenMode")}
+          desc={t("settings.reading.defaultOpenModeDesc")}
         >
-          <Toggle
-            checked={prefs.autoExtract}
-            onChange={(v) => setPref({ autoExtract: v })}
+          <Select
+            value={prefs.defaultOpenMode}
+            options={[
+              { value: "reader", label: t("settings.subscriptions.openReader") },
+              {
+                value: "extracted",
+                label: t("settings.subscriptions.openExtracted"),
+              },
+              { value: "web", label: t("settings.subscriptions.openWeb") },
+            ]}
+            onChange={(v) => setPref({ defaultOpenMode: v as OpenMode })}
           />
         </Row>
       </div>
@@ -799,6 +807,22 @@ function SubscriptionsSection({
   const updateAutoTranslate = (f: Feed, enabled: boolean) => {
     api
       .setFeedAutoTranslate(f.id, enabled)
+      .then(() => qc.invalidateQueries({ queryKey: ["feeds"] }))
+      .catch((e) => reportError(e));
+  };
+  // Per-feed open mode (issue #110): how the feed's articles open in the
+  // reader pane. "default" ⇒ null (reader view, honouring the global
+  // auto-extract preference).
+  const openModeOptions = [
+    { value: "default", label: t("settings.subscriptions.openDefault") },
+    { value: "reader", label: t("settings.subscriptions.openReader") },
+    { value: "extracted", label: t("settings.subscriptions.openExtracted") },
+    { value: "web", label: t("settings.subscriptions.openWeb") },
+  ];
+  const updateOpenMode = (f: Feed, v: string) => {
+    const mode = v === "default" ? null : (v as "reader" | "extracted" | "web");
+    api
+      .setFeedOpenMode(f.id, mode)
       .then(() => qc.invalidateQueries({ queryKey: ["feeds"] }))
       .catch((e) => reportError(e));
   };
@@ -917,6 +941,12 @@ function SubscriptionsSection({
                     aria-label={t("settings.subscriptions.autoTranslate")}
                   />
                 </label>
+                <Select
+                  value={f.openMode ?? "default"}
+                  options={openModeOptions}
+                  onChange={(v) => updateOpenMode(f, v)}
+                  aria-label={t("settings.subscriptions.openMode")}
+                />
                 <Select
                   value={intervalValue(f.refreshIntervalMin)}
                   options={intervalOptions}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -314,9 +314,9 @@
       "maxWidth": "Body max width",
       "readingTime": "Show estimated reading time",
       "readingTimeDesc": "Show estimated reading time in the article info bar",
-      "fulltext": "Full text",
-      "autoExtract": "Auto-extract full text",
-      "autoExtractDesc": "When opening a summary-only article, automatically fetch the full page content"
+      "openModeTitle": "Open mode",
+      "defaultOpenMode": "Open articles as",
+      "defaultOpenModeDesc": "How articles open by default — individual feeds can override this in Subscriptions"
     },
     "subscriptions": {
       "searchPlaceholder": "Search feeds…",
@@ -334,6 +334,11 @@
       "refreshOff": "Never",
       "autoTranslate": "Auto-translate",
       "autoTranslateDesc": "Translate articles from this feed automatically when opened",
+      "openMode": "Open articles as",
+      "openDefault": "Global default",
+      "openReader": "RSS text",
+      "openExtracted": "Full text",
+      "openWeb": "Web page",
       "unsubscribe": "Unsubscribe",
       "noMatch": "No matching feeds.",
       "opmlExported": "OPML exported to the Downloads folder",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -314,9 +314,9 @@
       "maxWidth": "本文の最大幅",
       "readingTime": "推定読了時間を表示",
       "readingTimeDesc": "記事情報バーに推定読了時間を表示します",
-      "fulltext": "全文",
-      "autoExtract": "全文を自動取得",
-      "autoExtractDesc": "要約のみの記事を開いたとき、ページ全文を自動的に取得します"
+      "openModeTitle": "表示方法",
+      "defaultOpenMode": "記事のデフォルト表示",
+      "defaultOpenModeDesc": "記事を開くときのデフォルトの表示方法。フィードごとに上書きできます"
     },
     "subscriptions": {
       "searchPlaceholder": "フィードを検索…",
@@ -334,6 +334,11 @@
       "refreshOff": "なし",
       "autoTranslate": "自動翻訳",
       "autoTranslateDesc": "このフィードの記事を開いたときに自動的に翻訳します",
+      "openMode": "記事の表示方法",
+      "openDefault": "全体設定に従う",
+      "openReader": "RSS 本文",
+      "openExtracted": "全文を自動取得",
+      "openWeb": "Web ページ",
       "unsubscribe": "購読解除",
       "noMatch": "一致するフィードがありません。",
       "opmlExported": "OPML をダウンロードフォルダにエクスポートしました",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -314,9 +314,9 @@
       "maxWidth": "正文最大宽度",
       "readingTime": "显示预计阅读时间",
       "readingTimeDesc": "在文章信息栏显示估算阅读时长",
-      "fulltext": "全文",
-      "autoExtract": "自动提取全文",
-      "autoExtractDesc": "打开只有摘要的文章时，自动抓取网页正文"
+      "openModeTitle": "打开方式",
+      "defaultOpenMode": "默认打开方式",
+      "defaultOpenModeDesc": "文章默认的打开方式，可在订阅源列表中按源覆盖"
     },
     "subscriptions": {
       "searchPlaceholder": "在订阅源中查找…",
@@ -334,6 +334,11 @@
       "refreshOff": "从不",
       "autoTranslate": "自动翻译",
       "autoTranslateDesc": "打开此订阅源的文章时自动翻译",
+      "openMode": "打开方式",
+      "openDefault": "跟随全局",
+      "openReader": "RSS 正文",
+      "openExtracted": "自动全文",
+      "openWeb": "网页视图",
       "unsubscribe": "退订",
       "noMatch": "没有匹配的订阅源。",
       "opmlExported": "OPML 已导出到下载文件夹",

--- a/src/store.ts
+++ b/src/store.ts
@@ -77,6 +77,11 @@ function clamp(n: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, n));
 }
 
+/** How an article opens by default: reader view, auto-extracted full text,
+ *  or the embedded web view. Individual feeds can override it (`Feed.openMode`). */
+export type OpenMode = "reader" | "extracted" | "web";
+export const OPEN_MODES: readonly OpenMode[] = ["reader", "extracted", "web"];
+
 /** Behavioural preferences driven by the Settings panel. */
 export interface Prefs {
   showSidebarCounts: boolean;
@@ -85,7 +90,7 @@ export interface Prefs {
   showReadingTime: boolean;
   markReadOnOpen: boolean;
   markReadOnScroll: boolean;
-  autoExtract: boolean;
+  defaultOpenMode: OpenMode;
   startupView: StartupView;
   hideReadOnStartup: boolean;
   /** Sidebar "unread only" mode — hide feeds with no unread articles. */
@@ -204,7 +209,7 @@ const PREF_KEYS: (keyof Prefs)[] = [
   "showReadingTime",
   "markReadOnOpen",
   "markReadOnScroll",
-  "autoExtract",
+  "defaultOpenMode",
   "startupView",
   "hideReadOnStartup",
   "sidebarUnreadOnly",
@@ -257,7 +262,13 @@ function loadPrefs(): Prefs {
     showReadingTime: ls.bool("pref.showReadingTime", true),
     markReadOnOpen: ls.bool("pref.markReadOnOpen", true),
     markReadOnScroll: ls.bool("pref.markReadOnScroll", false),
-    autoExtract: ls.bool("pref.autoExtract", false),
+    // Migrates the pre-0.15 boolean "auto-extract full text" toggle: a user
+    // who had it on keeps auto-extraction as their default open mode.
+    defaultOpenMode: ls.oneOf<OpenMode>(
+      "pref.defaultOpenMode",
+      OPEN_MODES,
+      ls.bool("pref.autoExtract", false) ? "extracted" : "reader",
+    ),
     startupView: ls.oneOf<StartupView>(
       "pref.startupView",
       ["all", "unread", "starred", "last"],

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,10 @@ export interface Feed {
   /** When true, opening an article from this feed auto-translates it into the
    *  configured target language. Defaults to false (show the original). */
   autoTranslate: boolean;
+  /** How articles from this feed open: reader view, auto-extracted full text,
+   *  or the embedded web view of the original page. `null` follows the default
+   *  behaviour (reader view, honouring the global auto-extract preference). */
+  openMode: "reader" | "extracted" | "web" | null;
 }
 
 export interface Enclosure {


### PR DESCRIPTION
Closes #110.

## What

Adds an **open mode** setting controlling how articles are displayed when opened — like Fluent Reader's per-source open target:

- **RSS text** — the feed's own content (today's reader view)
- **Full text** — automatically run full-text extraction on open
- **Web page** — load the original page in the embedded web view (the native child webview from #49)

It can be set in two places:

1. **Globally** (Settings → Reading): the old "Auto-extract full text" toggle is upgraded to a three-way "Open articles as" select. The legacy boolean preference is migrated (`on` → Full text, `off` → RSS text).
2. **Per feed** (Settings → Subscriptions): each feed row gets an open-mode select, defaulting to "Global default".

## Behaviour details

- The effective mode is the feed's setting, falling back to the global default. It is applied once per article, so the toolbar's web-view / extraction toggles still work as temporary overrides and a background feeds refetch never yanks the view back.
- Articles without a URL fall back to the reader view even in web mode.
- The 800-character "feed already delivers full text" heuristic is kept for the *global* Full text default (avoids pointless fetches), but an explicit per-feed **Full text** extracts unconditionally — the user asked for the page's own text for that feed.
- A per-feed **RSS text** also suppresses global auto-extraction for that feed, so the override works in both directions.

## Storage

New nullable `feeds.open_mode` column (migration v19) + `set_feed_open_mode` command, following the existing `refresh_interval_min` / `auto_translate` per-feed-setting pattern. Local-only, not synced to FreshRSS (the GReader protocol has no such concept). The global default lives in localStorage prefs like the toggle it replaces.

## Tests

- `cargo test` (216 tests, including a new open-mode round-trip test)
- `vitest` (76 tests), `tsc --noEmit` clean
- Manually verified in the running app (per-feed web view / full text / RSS text, global default migration, toolbar overrides)

🤖 Generated with [Claude Code](https://claude.com/claude-code)