### PR TITLE
feat: iOS mobile UI — stacked single-column navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import type { Palette, ResolvedMode } from "./store";
 import { useArticleActions } from "./hooks/articleActions";
 import { readCurrentItems } from "./lib/currentList";
 import { checkForUpdates } from "./lib/updater";
-import { isDesktop } from "./lib/platform";
+import { isDesktop, isMobile } from "./lib/platform";
 import { useToasts, toast as toastApi, reportError } from "./toast";
 import type { ArticleQuery, ArticleSummary, Feed } from "./types";
 import Sidebar from "./components/Sidebar";
@@ -25,6 +25,7 @@ import ExploreDialog from "./components/ExploreDialog";
 import PromptDialog from "./components/PromptDialog";
 import PlayerBar from "./components/PlayerBar";
 import ResizeHandle from "./components/ResizeHandle";
+import MobileShell from "./components/MobileShell";
 import Icon from "./components/Icon";
 import { PANEL_BOUNDS } from "./store";
 
@@ -527,6 +528,21 @@ export default function App() {
   return (
     <>
       <div className="app-shell">
+        {isMobile ? (
+          // Mobile (iOS): a stacked single-column navigation over the same
+          // Sidebar / ArticleList / Reader. The desktop three-pane grid and its
+          // resize handles are never rendered here — nothing below this branch
+          // (the `.window` grid) reaches a phone.
+          <MobileShell
+            onAddFeed={() => setAddFeed(true)}
+            onExplore={() => setExplore(true)}
+            onOpenSettings={openSettings}
+            onSearchClick={() => setCpOpen(true)}
+            onRefresh={doRefresh}
+            refreshing={refreshing}
+            onToast={showToast}
+          />
+        ) : (
         <div className={`window ${focusMode ? "focus" : ""}`}>
           <Sidebar
             onAddFeed={() => setAddFeed(true)}
@@ -573,6 +589,7 @@ export default function App() {
             </>
           )}
         </div>
+        )}
         <PlayerBar />
       </div>
 

--- a/src/components/ArticleList.tsx
+++ b/src/components/ArticleList.tsx
@@ -9,7 +9,7 @@ import { useArticleActions } from "../hooks/articleActions";
 import { listTranslationKey, useListTranslation } from "../listTranslation";
 import { resolveRowTranslation } from "../lib/rowTranslation";
 import { relTime } from "../lib/feedMeta";
-import { isMac, modCombo } from "../lib/platform";
+import { isMac, isMobile, modCombo } from "../lib/platform";
 import { reportError, toast } from "../toast";
 import { clampToViewport } from "../lib/viewport";
 import type { ArticleSummary, Feed } from "../types";
@@ -20,6 +20,10 @@ const PAGE = 60;
 
 interface Props {
   onToast: (msg: string) => void;
+  /** Mobile only: pop back to the sidebar. Renders a back chevron in the
+   *  header. Absent on desktop, where the sidebar is always visible. */
+  onBack?: () => void;
+  backLabel?: string;
 }
 
 interface Hover {
@@ -28,7 +32,7 @@ interface Hover {
   left: number;
 }
 
-export default function ArticleList({ onToast }: Props) {
+export default function ArticleList({ onToast, onBack, backLabel }: Props) {
   const { t, i18n } = useTranslation();
   const qc = useQueryClient();
   const actions = useArticleActions(toast.error);
@@ -324,6 +328,10 @@ export default function ArticleList({ onToast }: Props) {
   };
 
   const onHover = (a: ArticleSummary, e: React.MouseEvent) => {
+    // The hover preview is a pointer affordance — on touch a tap synthesises a
+    // mouseenter, which would flash the preview over the row the user is
+    // opening. Long-press (below) is the touch equivalent for the row menu.
+    if (isMobile) return;
     if (
       e.target instanceof Element &&
       e.target.closest("[data-no-hover-preview]")
@@ -348,6 +356,28 @@ export default function ArticleList({ onToast }: Props) {
     window.clearTimeout(hoverTimer.current);
     setHover(null);
   };
+
+  // ── touch long-press → the row context menu (mobile) ──
+  // Touch has no right-click, so a ~500ms press opens the same menu the desktop
+  // raises on `onContextMenu`. A press that fires the menu also suppresses the
+  // tap that would otherwise open the article (`pressFired`), and any scroll
+  // (touchmove) cancels the pending press so it never fights a fling-scroll.
+  const pressTimer = useRef<number | undefined>(undefined);
+  const pressFired = useRef(false);
+  const onRowTouchStart = (a: ArticleSummary, e: React.TouchEvent) => {
+    if (!isMobile) return;
+    pressFired.current = false;
+    const tch = e.touches[0];
+    const x = tch.clientX;
+    const y = tch.clientY;
+    window.clearTimeout(pressTimer.current);
+    pressTimer.current = window.setTimeout(() => {
+      pressFired.current = true;
+      setMenu({ x, y, article: a });
+    }, 500);
+  };
+  const cancelPress = () => window.clearTimeout(pressTimer.current);
+  useEffect(() => () => window.clearTimeout(pressTimer.current), []);
 
   const articleMenu = (a: ArticleSummary): MenuEntry[] => [
     { icon: "open", label: t("articleList.menuOpen"), shortcut: "⏎", onClick: () => openArticle(a.id) },
@@ -452,6 +482,16 @@ export default function ArticleList({ onToast }: Props) {
   return (
     <div className="list" role="region" aria-labelledby="article-list-title">
       <div className="list-header" {...(isMac && { "data-tauri-drag-region": true })}>
+        {onBack && (
+          <button
+            className="ms-back"
+            onClick={onBack}
+            aria-label={backLabel}
+            title={backLabel}
+          >
+            <Icon name="chevron-right" size={20} />
+          </button>
+        )}
         <h1 className="list-title" id="article-list-title">
           {/* Smart views re-translate live; feed/folder/tag keep their own title. */}
           {query.kind === "feed" ||
@@ -620,11 +660,23 @@ export default function ArticleList({ onToast }: Props) {
                     role="option"
                     id={`option-article-${a.id}`}
                     aria-selected={selectedId === a.id}
-                    onClick={() => openArticle(a.id)}
+                    onClick={() => {
+                      // A completed long-press already opened the menu — swallow
+                      // the tap so the article doesn't also open behind it.
+                      if (pressFired.current) {
+                        pressFired.current = false;
+                        return;
+                      }
+                      openArticle(a.id);
+                    }}
                     onContextMenu={(e) => {
                       e.preventDefault();
                       setMenu({ x: e.clientX, y: e.clientY, article: a });
                     }}
+                    onTouchStart={(e) => onRowTouchStart(a, e)}
+                    onTouchMove={cancelPress}
+                    onTouchEnd={cancelPress}
+                    onTouchCancel={cancelPress}
                     onMouseEnter={(e) => onHover(a, e)}
                     onMouseLeave={leaveHover}
                   >

--- a/src/components/ArticleList.tsx
+++ b/src/components/ArticleList.tsx
@@ -10,6 +10,7 @@ import { listTranslationKey, useListTranslation } from "../listTranslation";
 import { resolveRowTranslation } from "../lib/rowTranslation";
 import { relTime } from "../lib/feedMeta";
 import { isMac, isMobile, modCombo } from "../lib/platform";
+import { isUrlOnlySnippet } from "../lib/snippetNoise";
 import { reportError, toast } from "../toast";
 import { clampToViewport } from "../lib/viewport";
 import type { ArticleSummary, Feed } from "../types";
@@ -479,6 +480,19 @@ export default function ArticleList({ onToast, onBack, backLabel }: Props) {
       .catch((e) => reportError(e));
   };
 
+  // Feed/folder/tag views carry their own title; smart views re-translate live.
+  const headerTitle =
+    query.kind === "feed" || query.kind === "folder" || query.kind === "tag"
+      ? queryLabel
+      : t(`smart.${query.kind}`);
+
+  // In a single-feed view every row belongs to the same feed, so repeating the
+  // feed name on each row's meta line is pure redundancy. On mobile — where the
+  // row is narrow and the name pushes the timestamp around — drop it and show
+  // just the time. Mixed views (all/unread/starred/readLater/folder/tag) still
+  // need the per-row feed name to tell sources apart, so they keep it.
+  const hideRowFeed = isMobile && query.kind === "feed";
+
   return (
     <div className="list" role="region" aria-labelledby="article-list-title">
       <div className="list-header" {...(isMac && { "data-tauri-drag-region": true })}>
@@ -494,11 +508,15 @@ export default function ArticleList({ onToast, onBack, backLabel }: Props) {
         )}
         <h1 className="list-title" id="article-list-title">
           {/* Smart views re-translate live; feed/folder/tag keep their own title. */}
-          {query.kind === "feed" ||
-          query.kind === "folder" ||
-          query.kind === "tag"
-            ? queryLabel
-            : t(`smart.${query.kind}`)}
+          {/* On mobile the title shares one narrow row with the count + translate
+              pills, so it's wrapped in a shrinkable span that truncates with an
+              ellipsis (styled under [data-mobile]) — keeping the trailing pills
+              inside the safe area. Desktop keeps the bare text node unchanged. */}
+          {isMobile ? (
+            <span className="list-title-text">{headerTitle}</span>
+          ) : (
+            headerTitle
+          )}
           <span className="list-title-meta">
             <span className="count">
               {browse.isLoading ? t("common.loading") : showCount}
@@ -685,11 +703,16 @@ export default function ArticleList({ onToast, onBack, backLabel }: Props) {
                     )}
                     <div className="art-head">
                       {!a.isRead && <span className="art-dot" />}
-                      <span className="art-feed">{a.feedTitle}</span>
+                      {!hideRowFeed && (
+                        <span className="art-feed">{a.feedTitle}</span>
+                      )}
                       {feed && feed.sourceType !== "rss" && (
                         <span className="src-badge">{feed.sourceType}</span>
                       )}
-                      <span className="art-sep">·</span>
+                      {/* The separator only makes sense between the feed name
+                          and the time; with the name gone it would be a
+                          dangling "·", so drop it too. */}
+                      {!hideRowFeed && <span className="art-sep">·</span>}
                       <span className="art-time">{relTime(a.publishedAt)}</span>
                       {(rt.isTranslating || rt.error) && (
                         <span
@@ -726,7 +749,12 @@ export default function ArticleList({ onToast, onBack, backLabel }: Props) {
                     <h3 className="art-title" title={rt.hasTranslation ? a.title : undefined}>
                       {rt.title}
                     </h3>
-                    {rt.snippet && (
+                    {/* On mobile, suppress snippets that are only link
+                        boilerplate (e.g. HN's "Article URL: … Comments URL: …"),
+                        which otherwise fill both snippet lines with noise. A
+                        translated snippet is real prose, so never suppress it. */}
+                    {rt.snippet &&
+                      !(isMobile && !rt.hasTranslation && isUrlOnlySnippet(rt.snippet)) && (
                       <p
                         className="art-snippet"
                         title={rt.hasTranslation ? (a.snippet ?? undefined) : undefined}

--- a/src/components/MobileShell.tsx
+++ b/src/components/MobileShell.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useUi } from "../store";
+import Sidebar from "./Sidebar";
+import ArticleList from "./ArticleList";
+import Reader from "./Reader";
+
+interface Props {
+  onAddFeed: () => void;
+  onExplore: () => void;
+  onOpenSettings: (section?: string) => void;
+  onSearchClick: () => void;
+  onRefresh: (scope?: { feedId?: number; folderId?: number }) => void;
+  refreshing: boolean;
+  onToast: (msg: string) => void;
+}
+
+/** The three navigation levels, stacked. The current level is *derived* from
+ *  the store rather than tracked in a parallel router: opening an article
+ *  (`selectedArticleId != null`) is the reader level; otherwise a pushed list
+ *  flag distinguishes the list level from the sidebar (home) level. That keeps
+ *  a single source of truth — the same selection state the desktop three-pane
+ *  layout reads — so nothing can drift out of sync. */
+const SIDEBAR = 0;
+const LIST = 1;
+const READER = 2;
+
+/** Fraction of the pane width a back-swipe must cross to commit the pop; below
+ *  it the pane springs back. Mirrors the iOS interactive-pop feel. */
+const SWIPE_COMMIT = 0.4;
+/** Only a touch starting within this many px of the left edge begins an
+ *  edge-swipe — the same "screen-edge pan" gesture iOS uses for back, so a
+ *  normal in-content drag/scroll is never hijacked. */
+const EDGE_ZONE = 28;
+
+/**
+ * Mobile (iOS) shell: a stacked single-column navigation over the *same*
+ * Sidebar / ArticleList / Reader the desktop renders — only the layout differs.
+ * All three panes are always mounted (absolutely positioned, full-width) and
+ * slid horizontally by a transform keyed off the current level, so React state
+ * and each pane's scroll position survive a push/pop. Selecting a view pushes
+ * the list; opening an article pushes the reader; the top-left chevron (and an
+ * iOS-style left-edge back-swipe) pops one level.
+ */
+export default function MobileShell({
+  onAddFeed,
+  onExplore,
+  onOpenSettings,
+  onSearchClick,
+  onRefresh,
+  refreshing,
+  onToast,
+}: Props) {
+  const { t } = useTranslation();
+  const selectedArticleId = useUi((s) => s.selectedArticleId);
+  const openArticle = useUi((s) => s.openArticle);
+
+  // The one bit of navigation state that isn't already derivable from the
+  // selection: whether the article list has been pushed over the sidebar. The
+  // reader level is derived from `selectedArticleId`, so no separate flag.
+  const [listOpen, setListOpen] = useState(false);
+
+  const level = selectedArticleId != null ? READER : listOpen ? LIST : SIDEBAR;
+
+  // An article can be opened without going through the sidebar (command
+  // palette, a deep link) — keep the list beneath the reader so a back-swipe or
+  // chevron lands on the list rather than skipping straight home.
+  useEffect(() => {
+    if (selectedArticleId != null) setListOpen(true);
+  }, [selectedArticleId]);
+
+  const back = () => {
+    if (level === READER) openArticle(null);
+    else if (level === LIST) setListOpen(false);
+  };
+
+  // ── interactive left-edge back-swipe ──
+  // A lightweight touch handler (no gesture lib): follow the finger with a live
+  // translateX while dragging, commit the pop past a threshold, else spring
+  // back. `drag` is the horizontal offset in px while a swipe is in progress,
+  // or null when idle. The `.dragging` class suspends the pane transition so
+  // the follow is 1:1; releasing re-enables it to animate to rest. When the
+  // reduce-motion preference (or the OS setting) is on, the global rule in
+  // styles.css collapses that transition to ~0ms, so the pop is instant — the
+  // gesture still works, it just doesn't animate.
+  const [drag, setDrag] = useState<number | null>(null);
+  const startX = useRef(0);
+  const startY = useRef(0);
+  const width = useRef(1);
+  const active = useRef(false);
+
+  const onTouchStart = (e: React.TouchEvent) => {
+    if (level === SIDEBAR) return; // nothing to pop back to
+    const tch = e.touches[0];
+    if (tch.clientX > EDGE_ZONE) return;
+    startX.current = tch.clientX;
+    startY.current = tch.clientY;
+    width.current = e.currentTarget.clientWidth || window.innerWidth;
+    active.current = true;
+  };
+  const onTouchMove = (e: React.TouchEvent) => {
+    if (!active.current) return;
+    const tch = e.touches[0];
+    const dx = tch.clientX - startX.current;
+    const dy = tch.clientY - startY.current;
+    // A clearly vertical first move is a scroll, not a back-swipe — bail so we
+    // never fight the pane's own scrolling.
+    if (drag == null && Math.abs(dy) > Math.abs(dx) && Math.abs(dy) > 10) {
+      active.current = false;
+      return;
+    }
+    if (dx > 0) setDrag(dx);
+  };
+  const onTouchEnd = () => {
+    if (!active.current) return;
+    active.current = false;
+    if ((drag ?? 0) > width.current * SWIPE_COMMIT) back();
+    setDrag(null);
+  };
+
+  // Resting transform (in %) for a pane at `index`, given the active level and
+  // any in-progress swipe. The active pane sits at 0; deeper panes are off to
+  // the right (100%); the pane one level up sits slightly left (parallax, the
+  // iOS "card behind" look). A swipe drags the active pane right and pulls the
+  // pane beneath it back toward 0.
+  const paneTransform = (index: number): string => {
+    let pct: number;
+    if (index < level) pct = -22; // beneath the stack, parallaxed left
+    else if (index === level) pct = 0; // active
+    else pct = 100; // not yet reached, off-screen right
+    if (drag != null && level > SIDEBAR) {
+      const f = Math.min(1, Math.max(0, drag / width.current));
+      if (index === level) pct = f * 100;
+      else if (index === level - 1) pct = -22 + f * 22;
+    }
+    return `translateX(${pct}%)`;
+  };
+
+  const backLabel = t("common.back");
+
+  return (
+    <div
+      className={`mobile-shell${drag != null ? " dragging" : ""}`}
+      data-level={level}
+      onTouchStart={onTouchStart}
+      onTouchMove={onTouchMove}
+      onTouchEnd={onTouchEnd}
+      onTouchCancel={onTouchEnd}
+    >
+      <div
+        className="ms-pane ms-sidebar"
+        style={{ transform: paneTransform(SIDEBAR) }}
+        aria-hidden={level !== SIDEBAR}
+      >
+        <Sidebar
+          onAddFeed={onAddFeed}
+          onExplore={onExplore}
+          onOpenSettings={onOpenSettings}
+          onSearchClick={onSearchClick}
+          onRefresh={onRefresh}
+          refreshing={refreshing}
+          onToast={onToast}
+          onSelectView={() => setListOpen(true)}
+        />
+      </div>
+      <div
+        className="ms-pane ms-list"
+        style={{ transform: paneTransform(LIST) }}
+        aria-hidden={level !== LIST}
+      >
+        <ArticleList onToast={onToast} onBack={back} backLabel={backLabel} />
+      </div>
+      <div
+        className="ms-pane ms-reader"
+        style={{ transform: paneTransform(READER) }}
+        aria-hidden={level !== READER}
+      >
+        <Reader onToast={onToast} onBack={back} backLabel={backLabel} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -25,6 +25,29 @@ import Lightbox from "./Lightbox";
 
 interface Props {
   onToast: (msg: string) => void;
+  /** Mobile only: pop back to the article list. Renders a back chevron as the
+   *  first item of the reader toolbar. Absent on desktop, where the list stays
+   *  visible beside the reader. */
+  onBack?: () => void;
+  backLabel?: string;
+}
+
+/** The reader toolbar's leading back chevron — mobile only (rendered when a
+ *  pop handler is supplied). A shared helper so every toolbar variant (loaded,
+ *  loading, error) shows the identical affordance. */
+function BackButton({
+  onBack,
+  backLabel,
+}: {
+  onBack?: () => void;
+  backLabel?: string;
+}) {
+  if (!onBack) return null;
+  return (
+    <button className="ms-back" onClick={onBack} aria-label={backLabel} title={backLabel}>
+      <Icon name="chevron-right" size={20} />
+    </button>
+  );
 }
 
 function youtubeId(url: string | null): string | null {
@@ -175,7 +198,7 @@ function makeLinkClickHandler(sourceUrl: string | null) {
   };
 }
 
-export default function Reader({ onToast }: Props) {
+export default function Reader({ onToast, onBack, backLabel }: Props) {
   const { t, i18n } = useTranslation();
   const qc = useQueryClient();
   const actions = useArticleActions(toast.error);
@@ -734,7 +757,13 @@ export default function Reader({ onToast }: Props) {
   if (!a) {
     return (
       <div className="reader" role="main">
-        {isMac && <div className="reader-toolbar" data-tauri-drag-region />}
+        {/* Keep the back affordance while the article detail is still loading /
+            errored (mobile), so the user is never stranded on a blank reader. */}
+        {(isMac || onBack) && (
+          <div className="reader-toolbar" {...(isMac && { "data-tauri-drag-region": true })}>
+            <BackButton onBack={onBack} backLabel={backLabel} />
+          </div>
+        )}
         {article.isError ? (
           <div className="empty" style={{ flex: 1 }}>
             <div className="glyph">
@@ -797,6 +826,7 @@ export default function Reader({ onToast }: Props) {
         className={`reader-toolbar ${scrolled ? "scrolled" : ""}`}
         {...(isMac && { "data-tauri-drag-region": true })}
       >
+        <BackButton onBack={onBack} backLabel={backLabel} />
         <button
           className={`tb-btn ${a.isStarred ? "on" : ""}`}
           onClick={() => actions.setStarred(a.id, !a.isStarred)}

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -9,7 +9,7 @@ import { useArticleActions } from "../hooks/articleActions";
 import { useFocusTrap } from "../hooks/useFocusTrap";
 import { LANGUAGES, setLanguage, type Language } from "../i18n";
 import { feedHost } from "../lib/feedMeta";
-import { modKey, modCombo, isDesktop } from "../lib/platform";
+import { modKey, modCombo, isDesktop, isMobile } from "../lib/platform";
 import { reportError } from "../toast";
 import { checkForUpdates } from "../lib/updater";
 import { downloadFile } from "../lib/download";
@@ -70,6 +70,12 @@ export default function SettingsDialog({
 }: Props) {
   const { t } = useTranslation();
   const [section, setSection] = useState(initialSection ?? "general");
+  // Mobile only: whether a section is pushed over the section list (the same
+  // one-flag drill-down MobileShell uses). Opening with an explicit
+  // `initialSection` (⌘, → subscriptions from the OPML command, etc.) lands
+  // directly on that section, with the back chevron leading to the list.
+  // Unused on desktop, where the rail and content are side by side.
+  const [sectionOpen, setSectionOpen] = useState(initialSection != null);
   const feeds = useQuery({ queryKey: ["feeds"], queryFn: api.listFeeds });
   const windowRef = useRef<HTMLDivElement>(null);
   const version = useAppVersion();
@@ -102,6 +108,42 @@ export default function SettingsDialog({
     about: t("settings.sub.about"),
   };
 
+  // The active section's pane, shared verbatim by the desktop and mobile
+  // layouts — only the chrome around it differs, so the sections themselves
+  // are never forked.
+  const sectionContent = (
+    <div className="settings-scroll">
+      {section === "general" && <GeneralSection />}
+      {section === "appearance" && <AppearanceSection />}
+      {section === "reading" && <ReadingSection />}
+      {section === "subscriptions" && (
+        <SubscriptionsSection
+          feeds={feeds.data ?? []}
+          onToast={onToast}
+          onAddFeed={onAddFeed}
+        />
+      )}
+      {section === "filters" && (
+        <FiltersSection feeds={feeds.data ?? []} onToast={onToast} />
+      )}
+      {section === "sync" && <SyncSection onToast={onToast} />}
+      {section === "shortcuts" && <ShortcutsSection />}
+      {section === "notifications" && <NotificationsSection />}
+      {section === "advanced" && <AdvancedSection onToast={onToast} />}
+      {section === "about" && <AboutSection />}
+    </div>
+  );
+
+  const closeButton = (
+    <button
+      className="settings-close"
+      onClick={onClose}
+      title={t("settings.closeTitle")}
+    >
+      <Icon name="x" size={15} />
+    </button>
+  );
+
   return (
     <div className="settings-backdrop" onClick={onClose}>
       <div
@@ -112,63 +154,102 @@ export default function SettingsDialog({
         aria-label={t("settings.title")}
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="settings-sidebar">
-          <div className="settings-sidebar-title">
-            {t("settings.title")}
-            <span className="badge">{modCombo(",")}</span>
-          </div>
-          {SECTIONS.map((s) => (
+        {isMobile ? (
+          // Mobile: an iOS-style two-level drill-down instead of the desktop
+          // rail + content grid. Level 1 is the full-width section list; tapping
+          // a row pushes level 2 (that section's pane) with a back chevron.
+          // Both panes stay mounted and slide via the same translateX push/pop
+          // MobileShell uses (`.pushed` drives the CSS); `inert` keeps the
+          // off-screen pane out of the focus trap and screen-reader order.
+          <div className={`settings-mobile ${sectionOpen ? "pushed" : ""}`}>
             <div
-              key={s.id}
-              className={`settings-nav-item ${section === s.id ? "active" : ""}`}
-              onClick={() => setSection(s.id)}
+              className="settings-m-pane settings-m-nav"
+              inert={sectionOpen || undefined}
             >
-              <span className="nav-ico">
-                <Icon name={s.icon} size={15} />
-              </span>
-              {t(s.labelKey)}
+              <div className="settings-m-header">
+                <h2>{t("settings.title")}</h2>
+                {closeButton}
+              </div>
+              <div className="settings-m-list">
+                {SECTIONS.map((s) => (
+                  <button
+                    key={s.id}
+                    type="button"
+                    className="settings-m-item"
+                    onClick={() => {
+                      setSection(s.id);
+                      setSectionOpen(true);
+                    }}
+                  >
+                    <span className="nav-ico">
+                      <Icon name={s.icon} size={16} />
+                    </span>
+                    <span className="settings-m-item-label">{t(s.labelKey)}</span>
+                    <span className="settings-m-chevron" aria-hidden="true">
+                      <Icon name="chevron-right" size={14} />
+                    </span>
+                  </button>
+                ))}
+                <div className="settings-version">
+                  Papr{version && ` ${version}`}
+                </div>
+              </div>
             </div>
-          ))}
-          <div className="settings-nav-spacer" />
-          <div className="settings-version">
-            Papr{version && ` ${version}`}
+            <div
+              className="settings-m-pane settings-m-section"
+              inert={!sectionOpen || undefined}
+            >
+              <div className="settings-m-header">
+                <button
+                  className="ms-back"
+                  onClick={() => setSectionOpen(false)}
+                  aria-label={t("common.back")}
+                  title={t("common.back")}
+                >
+                  <Icon name="chevron-right" size={20} />
+                </button>
+                <h2>{t(cur.labelKey)}</h2>
+                {closeButton}
+              </div>
+              {sectionContent}
+            </div>
           </div>
-        </div>
+        ) : (
+          <>
+            <div className="settings-sidebar">
+              <div className="settings-sidebar-title">
+                {t("settings.title")}
+                <span className="badge">{modCombo(",")}</span>
+              </div>
+              {SECTIONS.map((s) => (
+                <div
+                  key={s.id}
+                  className={`settings-nav-item ${section === s.id ? "active" : ""}`}
+                  onClick={() => setSection(s.id)}
+                >
+                  <span className="nav-ico">
+                    <Icon name={s.icon} size={15} />
+                  </span>
+                  {t(s.labelKey)}
+                </div>
+              ))}
+              <div className="settings-nav-spacer" />
+              <div className="settings-version">
+                Papr{version && ` ${version}`}
+              </div>
+            </div>
 
-        <div className="settings-content">
-          <div className="settings-header">
-            <h2>{t(cur.labelKey)}</h2>
-            <span className="sub">{subs[section]}</span>
-          </div>
-          <button
-            className="settings-close"
-            onClick={onClose}
-            title={t("settings.closeTitle")}
-          >
-            <Icon name="x" size={15} />
-          </button>
+            <div className="settings-content">
+              <div className="settings-header">
+                <h2>{t(cur.labelKey)}</h2>
+                <span className="sub">{subs[section]}</span>
+              </div>
+              {closeButton}
 
-          <div className="settings-scroll">
-            {section === "general" && <GeneralSection />}
-            {section === "appearance" && <AppearanceSection />}
-            {section === "reading" && <ReadingSection />}
-            {section === "subscriptions" && (
-              <SubscriptionsSection
-                feeds={feeds.data ?? []}
-                onToast={onToast}
-                onAddFeed={onAddFeed}
-              />
-            )}
-            {section === "filters" && (
-              <FiltersSection feeds={feeds.data ?? []} onToast={onToast} />
-            )}
-            {section === "sync" && <SyncSection onToast={onToast} />}
-            {section === "shortcuts" && <ShortcutsSection />}
-            {section === "notifications" && <NotificationsSection />}
-            {section === "advanced" && <AdvancedSection onToast={onToast} />}
-            {section === "about" && <AboutSection />}
-          </div>
-        </div>
+              {sectionContent}
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -24,6 +24,10 @@ interface Props {
   onRefresh: (scope?: { feedId?: number; folderId?: number }) => void;
   refreshing: boolean;
   onToast: (msg: string) => void;
+  /** Mobile only: called after any view (smart view / feed / folder / tag) is
+   *  selected, so the shell can push the article-list level over the sidebar.
+   *  Absent on desktop, where the list is always visible beside the sidebar. */
+  onSelectView?: () => void;
 }
 
 const sameQuery = (a: ArticleQuery, b: ArticleQuery) =>
@@ -89,12 +93,23 @@ export default function Sidebar({
   onRefresh,
   refreshing,
   onToast,
+  onSelectView,
 }: Props) {
   const { t } = useTranslation();
   const qc = useQueryClient();
   const actions = useArticleActions();
   const query = useUi((s) => s.query);
-  const select = useUi((s) => s.select);
+  const rawSelect = useUi((s) => s.select);
+  // Wrap the store's `select` so every selection — from the many call sites
+  // below (smart views, feed rows, folders, tags) — also notifies the mobile
+  // shell to push the list level, without threading a callback through each.
+  // On desktop `onSelectView` is undefined, so this is exactly the raw select.
+  const select: typeof rawSelect = onSelectView
+    ? (query, label) => {
+        rawSelect(query, label);
+        onSelectView();
+      }
+    : rawSelect;
   const showCounts = useUi((s) => s.prefs.showSidebarCounts);
   const unreadOnly = useUi((s) => s.prefs.sidebarUnreadOnly);
   const setPref = useUi((s) => s.setPref);

--- a/src/lib/snippetNoise.test.ts
+++ b/src/lib/snippetNoise.test.ts
@@ -1,0 +1,55 @@
+// Unit tests for the pure `isUrlOnlySnippet` heuristic. Exercisable in a plain
+// node environment — the helper takes the snippet text as its only argument.
+
+import { describe, it, expect } from "vitest";
+import { isUrlOnlySnippet } from "./snippetNoise";
+
+describe("isUrlOnlySnippet", () => {
+  it("flags the Hacker News two-URL boilerplate", () => {
+    const hn =
+      "Article URL: https://example.com/some-post Comments URL: https://news.ycombinator.com/item?id=42";
+    expect(isUrlOnlySnippet(hn)).toBe(true);
+  });
+
+  it("flags a single labelled URL", () => {
+    expect(isUrlOnlySnippet("Article URL: https://example.com/x")).toBe(true);
+  });
+
+  it("flags a bare URL with no label", () => {
+    expect(isUrlOnlySnippet("https://example.com/a/very/long/path")).toBe(true);
+  });
+
+  it("flags a bare www URL", () => {
+    expect(isUrlOnlySnippet("www.example.com/read-more")).toBe(true);
+  });
+
+  it("keeps a real sentence that merely contains a URL", () => {
+    const s =
+      "A deep dive into the new API design, with benchmarks at https://example.com/bench";
+    expect(isUrlOnlySnippet(s)).toBe(false);
+  });
+
+  it("keeps a real sentence introduced by a URL label", () => {
+    const s =
+      "Source URL: the maintainers have shipped a rewrite that halves cold-start time";
+    expect(isUrlOnlySnippet(s)).toBe(false);
+  });
+
+  it("keeps a normal prose snippet with no links at all", () => {
+    expect(
+      isUrlOnlySnippet("The quick brown fox jumps over the lazy dog."),
+    ).toBe(false);
+  });
+
+  it("keeps short-but-real prose right at the threshold", () => {
+    // "Read more at" -> 10 non-whitespace chars survive the URL strip -> kept.
+    expect(isUrlOnlySnippet("Read more at https://example.com")).toBe(false);
+  });
+
+  it("treats empty / null / whitespace as not-noise (nothing to hide)", () => {
+    expect(isUrlOnlySnippet("")).toBe(false);
+    expect(isUrlOnlySnippet(null)).toBe(false);
+    expect(isUrlOnlySnippet(undefined)).toBe(false);
+    expect(isUrlOnlySnippet("   \n  ")).toBe(false);
+  });
+});

--- a/src/lib/snippetNoise.ts
+++ b/src/lib/snippetNoise.ts
@@ -1,0 +1,38 @@
+// Pure helper for spotting article-list snippets that carry no real prose —
+// only link boilerplate. Kept free of any React/Tauri imports so it is
+// unit-testable in a plain node environment (see snippetNoise.test.ts).
+
+// How many non-whitespace characters of *real* text must survive the URL/label
+// strip for a snippet to count as meaningful. Below this the snippet is judged
+// pure link noise. ~10 clears "Read more at <url>" (10 chars of prose remain)
+// while catching the bare "Article URL: … Comments URL: …" case (0 remain).
+const MIN_MEANINGFUL_CHARS = 10;
+
+/**
+ * Is this list-row snippet nothing but link boilerplate?
+ *
+ * The canonical offender is Hacker News' firehose, whose RSS <description> is
+ * literally `Article URL: https://… Comments URL: https://…`. Rendered verbatim
+ * in a two-line row snippet it's pure noise, so on mobile we skip drawing it.
+ *
+ * Conservative by construction: we only ever *remove* URL tokens and the short
+ * "<word> URL:" / "<word> Link:" labels that introduce them, then ask whether
+ * any real text survived. A normal snippet that merely *contains* a URL keeps
+ * well over `MIN_MEANINGFUL_CHARS` of leftover prose and is therefore kept —
+ * we deliberately under-match rather than risk hiding a real snippet.
+ */
+export function isUrlOnlySnippet(text: string | null | undefined): boolean {
+  if (!text || !text.trim()) return false;
+  let rest = text;
+  // 1. Drop whole URLs — http/https tokens and bare `www.host` forms. `\S+`
+  //    consumes the URL up to the next space, including any trailing slash or
+  //    query string, so nothing URL-shaped is left to count as prose.
+  rest = rest.replace(/(?:https?:\/\/|www\.)\S+/gi, " ");
+  // 2. Drop the short labels that introduce those URLs: "Article URL:",
+  //    "Comments URL:", "Source Link:", or a bare "URL:" / "Link:". Anchored to
+  //    a single optional leading word so we don't chew into ordinary sentences.
+  rest = rest.replace(/\b(?:\w+\s+)?(?:URL|Link)\s*:/gi, " ");
+  // 3. Whatever's left, minus whitespace, is the surviving prose.
+  const meaningful = rest.replace(/\s+/g, "");
+  return meaningful.length < MIN_MEANINGFUL_CHARS;
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -5,6 +5,7 @@
     "save": "Save",
     "delete": "Delete",
     "close": "Close",
+    "back": "Back",
     "rename": "Rename",
     "add": "Add",
     "remove": "Remove",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -5,6 +5,7 @@
     "save": "保存",
     "delete": "削除",
     "close": "閉じる",
+    "back": "戻る",
     "rename": "名前を変更",
     "add": "追加",
     "remove": "削除",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -5,6 +5,7 @@
     "save": "保存",
     "delete": "删除",
     "close": "关闭",
+    "back": "返回",
     "rename": "重命名",
     "add": "添加",
     "remove": "移除",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "./i18n";
 import App from "./App";
 import { ErrorBoundary } from "./components/ErrorBoundary";
-import { isMac } from "./lib/platform";
+import { isMac, isMobile } from "./lib/platform";
 // Bundle the three UI / reader fonts so Windows and Linux render with the
 // same letterforms macOS sees, instead of falling through to Arial / DejaVu.
 // Variable-weight woff2 — one file per family covers every weight the styles
@@ -20,6 +20,13 @@ import "./styles.css";
 // from the very first frame — otherwise Win/Linux would briefly show 38px of
 // dead space at the top before a layout-shifting effect runs.
 document.documentElement.dataset.platform = isMac ? "mac" : "other";
+
+// Tag the root as a mobile (iOS) build so the mobile-only CSS in styles.css
+// (the stacked single-column shell, safe-area chrome, full-screen sheets) takes
+// effect. Set once from the static platform detection and *only* when true, so
+// on desktop the attribute is simply absent and every `[data-mobile]` rule is
+// inert — the desktop layout renders exactly as before.
+if (isMobile) document.documentElement.dataset.mobile = "true";
 
 // Suppress the webview's default context menu — its "Reload / Back / Inspect"
 // entries belong to a browser, not a finished app. Editable surfaces still get

--- a/src/styles.css
+++ b/src/styles.css
@@ -3086,16 +3086,143 @@ button { font-family: inherit; }
   padding-top: env(safe-area-inset-top);
   padding-bottom: env(safe-area-inset-bottom);
 }
-/* Settings: keep the two-pane grid but fill the screen with a narrower rail. */
+/* Settings: full-screen sheet hosting an iOS-style two-level drill-down (the
+   desktop rail + content grid isn't rendered on mobile — see SettingsDialog).
+   `display: block` neutralises the desktop grid; the two `.settings-m-pane`s
+   are absolutely stacked and slid, mirroring MobileShell's push/pop. */
 [data-mobile] .settings-window {
   width: 100%;
   max-width: 100%;
   height: 100%;
   max-height: 100%;
   border-radius: 0;
-  grid-template-columns: 150px 1fr;
-  padding-top: env(safe-area-inset-top);
+  display: block;
+  overflow: hidden;
 }
+[data-mobile] .settings-mobile {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+}
+[data-mobile] .settings-m-pane {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--panel-2);
+  will-change: transform;
+  /* Same curve/duration as .ms-pane so the whole app's push/pop feels like one
+     system. Reduce-motion collapses this via the global rule above. */
+  transition: transform 0.34s cubic-bezier(0.32, 0.72, 0, 1);
+}
+[data-mobile] .settings-m-section {
+  transform: translateX(100%);
+  box-shadow: -8px 0 24px rgba(0, 0, 0, 0.16);
+}
+/* Pushed: section slides in, the list parallaxes left behind it (same -22%
+   "card behind" offset as the app shell). */
+[data-mobile] .settings-mobile.pushed .settings-m-nav { transform: translateX(-22%); }
+[data-mobile] .settings-mobile.pushed .settings-m-section { transform: translateX(0); }
+
+[data-mobile] .settings-m-header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: calc(env(safe-area-inset-top) + 8px) 12px 8px;
+  border-bottom: 1px solid var(--hair);
+  flex-shrink: 0;
+}
+[data-mobile] .settings-m-header h2 {
+  margin: 0;
+  flex: 1;
+  min-width: 0;
+  font-size: 17px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+/* The list header has no back chevron — inset its title to match the section
+   header's optical left edge. */
+[data-mobile] .settings-m-nav .settings-m-header h2 { padding-left: 8px; }
+/* The shared close (×) participates in the header row here instead of floating
+   over the desktop content pane; 40pt to be comfortably tappable. */
+[data-mobile] .settings-m-header .settings-close {
+  position: static;
+  width: 40px;
+  height: 40px;
+  flex-shrink: 0;
+}
+
+[data-mobile] .settings-m-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 6px 16px calc(env(safe-area-inset-bottom) + 16px);
+}
+[data-mobile] .settings-m-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  min-height: 48px;
+  background: none;
+  border: 0;
+  border-bottom: 1px solid var(--hair);
+  border-radius: 0;
+  padding: 0 2px;
+  font: inherit;
+  font-size: 15px;
+  color: var(--ink);
+  text-align: left;
+  cursor: pointer;
+}
+[data-mobile] .settings-m-item:last-of-type { border-bottom: 0; }
+[data-mobile] .settings-m-item .nav-ico {
+  width: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+  flex-shrink: 0;
+}
+[data-mobile] .settings-m-item-label { flex: 1; min-width: 0; }
+[data-mobile] .settings-m-chevron {
+  display: inline-flex;
+  color: var(--muted-2);
+  flex-shrink: 0;
+}
+
+/* ── settings content at phone width ──
+   The rows were laid out for a ~640px pane. At ~390px, let a row wrap: a small
+   control (toggle) stays beside its label, a wide one (segmented, slider,
+   select, input) drops below it, label-above-control style. */
+[data-mobile] .settings-scroll {
+  padding: 16px 16px calc(env(safe-area-inset-bottom) + 48px);
+}
+[data-mobile] .settings-row {
+  flex-wrap: wrap;
+  row-gap: 8px;
+}
+/* Reserve enough of the line that any control wider than ~35% wraps below. */
+[data-mobile] .settings-row-text { min-width: 60%; }
+[data-mobile] .settings-row-control {
+  max-width: 100%;
+  flex-wrap: wrap;
+}
+[data-mobile] .settings-row-control input { max-width: 100%; }
+/* Comfortable touch sizes for the row controls. */
+[data-mobile] .s-select { min-height: 36px; }
+[data-mobile] .s-btn { min-height: 38px; }
+[data-mobile] .s-toggle { width: 44px; height: 26px; }
+[data-mobile] .s-toggle::before { width: 22px; height: 22px; }
+[data-mobile] .s-toggle:checked::before { transform: translateX(18px); }
+/* The shortcut table's two columns don't fit a phone. */
+[data-mobile] .s-shortcuts { grid-template-columns: 1fr; }
+/* Subscription feed rows (name · url · actions) wrap instead of clipping. */
+[data-mobile] .s-feed-row { flex-wrap: wrap; }
+[data-mobile] .s-feed-row .name { max-width: 100%; }
 /* AddFeed / Explore / Prompt modals → bottom sheets. */
 [data-mobile] .modal-backdrop { align-items: flex-end; }
 [data-mobile] .modal,

--- a/src/styles.css
+++ b/src/styles.css
@@ -2944,3 +2944,180 @@ button { font-family: inherit; }
 }
 .hl-export-menu .ctx-item:disabled,
 .send-to-menu .ctx-item:disabled { opacity: 0.5; cursor: default; }
+
+/* ============================================================================
+   MOBILE (iOS) — stacked single-column navigation
+   ----------------------------------------------------------------------------
+   Every rule in this block is scoped under `[data-mobile]`, an attribute set
+   ONCE on <html> from the static platform detection (main.tsx), and only when
+   the app runs in an iOS webview. On desktop the attribute is absent, so all of
+   the below is inert and the three-pane grid renders exactly as it always has.
+   The strategy is layout-only: the same Sidebar / ArticleList / Reader are
+   reused; here they're stacked full-width and slid horizontally instead of laid
+   out side by side. Reduce-motion is honoured by the global rule near the top
+   of this file (it collapses these transitions to ~0ms).
+   ========================================================================== */
+
+/* The shell that replaces the desktop `.window` grid — a positioning context
+   for the three absolutely-stacked panes. */
+[data-mobile] .mobile-shell {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--reader);
+}
+
+/* Each pane fills the shell and is offset by an inline translateX (set from
+   MobileShell). The transition animates a push/pop; `.dragging` suspends it so
+   an in-progress back-swipe follows the finger 1:1. */
+[data-mobile] .ms-pane {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  will-change: transform;
+  transition: transform 0.34s cubic-bezier(0.32, 0.72, 0, 1);
+  /* A deeper pane sliding in must paint over the parallaxed pane behind it;
+     the reader (last in DOM) is naturally on top, sidebar (first) at the back,
+     which matches the push order. A subtle edge shadow sells the depth. */
+  box-shadow: -8px 0 24px rgba(0, 0, 0, 0.16);
+}
+[data-mobile] .mobile-shell.dragging .ms-pane { transition: none; }
+/* The reused component roots don't set a fill height on their own (the desktop
+   grid sizes them) — stretch them to the pane here. */
+[data-mobile] .ms-pane > .sidebar,
+[data-mobile] .ms-pane > .list,
+[data-mobile] .ms-pane > .reader {
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  border-right: 0;
+}
+
+/* ── top-of-pane chrome / safe area ──
+   On an iPhone `isMac` is true, so the components render their macOS overlay
+   title-bar strip + drag region. Neither exists in a webview, so drop the drag
+   strip and re-inset each pane's header to the real status-bar / notch inset. */
+[data-mobile] .titlebar { display: none; }
+:root[data-mobile] .sidebar { padding-top: env(safe-area-inset-top); }
+:root[data-mobile] .sb-brand { margin-top: 14px; }
+:root[data-mobile] .list-header {
+  position: relative;
+  padding-top: calc(env(safe-area-inset-top) + 12px);
+  padding-left: 52px; /* clear the absolutely-positioned back chevron */
+}
+[data-mobile] .reader-toolbar {
+  height: auto;
+  min-height: 44px;
+  padding-top: calc(env(safe-area-inset-top) + 4px);
+  padding-left: 8px;
+  padding-right: 10px;
+  /* 8+ toolbar buttons can exceed a narrow phone width — let the row scroll
+     rather than overflow the viewport. */
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+[data-mobile] .reader-toolbar::-webkit-scrollbar { display: none; }
+
+/* ── back chevron (mobile only; injected into the list header + reader toolbar) ── */
+[data-mobile] .ms-back {
+  -webkit-appearance: none;
+  appearance: none;
+  background: none;
+  border: 0;
+  margin: 0;
+  padding: 0;
+  color: var(--accent);
+  width: 40px;
+  height: 40px;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+/* The icon set has no left chevron — flip the right one, as the lightbox does. */
+[data-mobile] .ms-back svg { transform: rotate(180deg); }
+[data-mobile] .list-header .ms-back {
+  position: absolute;
+  left: 8px;
+  top: calc(env(safe-area-inset-top) + 8px);
+}
+
+/* ── 44pt touch targets ── */
+[data-mobile] .sb-item { min-height: 44px; }
+[data-mobile] .sb-folder { min-height: 40px; }
+[data-mobile] .tb-btn { width: 40px; height: 40px; }
+[data-mobile] .list-meta-btn { min-height: 34px; }
+[data-mobile] .sidebar-search { height: 42px; font-size: 14px; }
+/* The ⌘K hint is meaningless without a hardware keyboard. */
+[data-mobile] .sidebar-search kbd { display: none; }
+
+/* ── the sidebar footer becomes a bottom tab bar ── */
+[data-mobile] .sb-footer {
+  padding: 8px 20px calc(8px + env(safe-area-inset-bottom));
+  gap: 8px;
+  justify-content: space-around;
+}
+[data-mobile] .sb-footer button { width: 44px; height: 44px; }
+
+/* ── toasts float above the bottom tab bar / home indicator ── */
+[data-mobile] .toast {
+  bottom: calc(env(safe-area-inset-bottom) + 72px);
+  max-width: calc(100vw - 24px);
+}
+
+/* ── dialogs become full-screen sheets ── */
+/* Command palette / full-screen search. */
+[data-mobile] .cp-backdrop {
+  padding-top: 0;
+  align-items: stretch;
+  justify-content: stretch;
+}
+[data-mobile] .cp {
+  width: 100%;
+  max-width: 100%;
+  border-radius: 0;
+  border: 0;
+  display: flex;
+  flex-direction: column;
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
+}
+/* Settings: keep the two-pane grid but fill the screen with a narrower rail. */
+[data-mobile] .settings-window {
+  width: 100%;
+  max-width: 100%;
+  height: 100%;
+  max-height: 100%;
+  border-radius: 0;
+  grid-template-columns: 150px 1fr;
+  padding-top: env(safe-area-inset-top);
+}
+/* AddFeed / Explore / Prompt modals → bottom sheets. */
+[data-mobile] .modal-backdrop { align-items: flex-end; }
+[data-mobile] .modal,
+[data-mobile] .modal-explore {
+  width: 100%;
+  max-width: 100%;
+  border-radius: 16px 16px 0 0;
+  padding-bottom: calc(18px + env(safe-area-inset-bottom));
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+/* ── audio mini-player: full-width, clear of the home indicator ── */
+[data-mobile] .player-bar {
+  height: auto;
+  min-height: 56px;
+  padding-bottom: env(safe-area-inset-bottom);
+}
+
+/* ── lightbox: honour the safe areas ── */
+[data-mobile] .lightbox { padding: 16px; }
+[data-mobile] .lightbox-close { top: calc(env(safe-area-inset-top) + 8px); }
+[data-mobile] .lightbox-counter {
+  bottom: calc(env(safe-area-inset-bottom) + 14px);
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -3008,6 +3008,24 @@ button { font-family: inherit; }
   padding-top: calc(env(safe-area-inset-top) + 12px);
   padding-left: 52px; /* clear the absolutely-positioned back chevron */
 }
+/* The title, the "N 篇" count and the translate pills all share one narrow row.
+   Let the title flex-shrink and truncate so the trailing pills can never be
+   pushed off the right edge / under the safe area. The meta group stays a fixed
+   size (flex-shrink: 0) so it's always fully visible; the title gives way. */
+[data-mobile] .list-title { gap: 8px; }
+[data-mobile] .list-title-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+[data-mobile] .list-title-meta { flex-shrink: 0; }
+/* Second toolbar row: keep the controls on one line at narrow widths — the
+   labels are short enough at zh/en/ja to fit 390pt, and the flex:1 spacer
+   between the left filters and "mark read" absorbs the slack. */
+[data-mobile] .list-meta { flex-wrap: nowrap; }
+[data-mobile] .list-meta-btn { white-space: nowrap; flex-shrink: 0; }
 [data-mobile] .reader-toolbar {
   height: auto;
   min-height: 44px;


### PR DESCRIPTION
## Summary

Phase 2 of iOS support (stacked on #111): replace the squished desktop three-pane grid with a mobile navigation shell. Desktop rendering is untouched.

### Navigation
- New `MobileShell` renders on mobile instead of the `.window` grid: three full-width panes — **sidebar (home) → article list → reader** — always mounted and slid by `translateX`, so pane state and scroll positions survive push/pop.
- The level is *derived* from existing store state (`selectedArticleId` + one local `listOpen` flag) rather than a parallel router, so the same selection state drives both layouts and can't drift.
- Back: a chevron in the list header / reader toolbar, plus an iOS-style **interactive left-edge back-swipe** (28px edge zone, finger-following transform with parallax on the pane beneath, 40% commit threshold, vertical-scroll bail-out, reduce-motion honored).

### Component reuse
`Sidebar` / `ArticleList` / `Reader` are reused, not rewritten:
- optional `onSelectView` (sidebar) and `onBack`/`backLabel` (list/reader) props — `undefined` on desktop, leaving those paths byte-identical;
- long-press (~500ms) on a list row opens the existing `ContextMenu` (touch has no right-click); a completed press swallows the synthetic tap; any scroll cancels it;
- the hover article preview is disabled on touch.

### Mobile chrome (CSS only)
All mobile rules live in one delimited block at the end of `styles.css`, every rule scoped under `[data-mobile]` — the attribute is set on `<html>` only when `isMobile`, so on desktop every rule is inert. Includes: safe-area insets, 44pt touch targets, bottom toolbar, toasts above the bottom bar, dialogs (Settings / AddFeed / Explore / CommandPalette) as full-screen sheets, PlayerBar/Lightbox safe-area fixes.

New `common.back` string added to en/ja/zh locales.

## Verification

- Verified visually in the iPhone 16 simulator with real feed data (hnrss.org): home, list, and reader levels all render correctly full-width with safe areas; back navigation returns through list to home; read-state changes made in the reader flowed back to the sidebar unread count.
- `pnpm build` and `pnpm test` green (81 passed).
- Desktop: shell markup unchanged (grid branch wrapped in a ternary, contents identical); zero existing CSS rules modified.

## Known follow-ups (out of scope)

- Phase 3: iOS notifications, deep-link registration, BGAppRefreshTask background refresh.



### Update

The Settings follow-up is now addressed in this PR: an iOS-style two-level drill-down (full-width section list → section pane with back chevron, `initialSection` lands directly at level 2), section components shared verbatim with the desktop layout, and content rows adapted for 390px width. Verified in the simulator; build/tests green.
